### PR TITLE
anchor: Support additional metadata fields

### DIFF
--- a/anchor/programs/glam/src/instructions/manager.rs
+++ b/anchor/programs/glam/src/instructions/manager.rs
@@ -166,11 +166,23 @@ pub fn initialize_fund_handler<'c: 'info, 'info>(
     solana_program::program::invoke_signed(
         &init_token_metadata_ix,
         &[
-            share_metadata,
-            share_metadata_authority,
-            share_mint,
-            share_mint_authority,
+            share_metadata.clone(),
+            share_metadata_authority.clone(),
+            share_mint.clone(),
+            share_mint_authority.clone(),
         ],
+        signer_seeds,
+    )?;
+    // Add additional metadata fields
+    solana_program::program::invoke_signed(
+        &spl_token_metadata_interface::instruction::update_field(
+            &spl_token_2022::id(),
+            &share_metadata.key(),
+            &share_metadata_authority.key(),
+            spl_token_metadata_interface::state::Field::Key("fund_id".to_string()),
+            fund_key.to_string(),
+        ),
+        &[share_mint.clone(), share_mint_authority.clone()],
         signer_seeds,
     )?;
 

--- a/anchor/programs/glam/src/state/fund.rs
+++ b/anchor/programs/glam/src/state/fund.rs
@@ -58,5 +58,8 @@ pub struct ShareClassMetadata {
 }
 impl ShareClassMetadata {
     // use the same max sizes as Fund
-    pub const INIT_SIZE: usize = MAX_FUND_NAME + MAX_FUND_SYMBOL + MAX_FUND_URI;
+    // more space needed for two reasons:
+    // 1. we need to support additional metadata
+    // 2. for each KV pair in metadata, keys ("name" etc) also take up space
+    pub const INIT_SIZE: usize = MAX_FUND_NAME + MAX_FUND_SYMBOL + MAX_FUND_URI + 100;
 }


### PR DESCRIPTION
In additional to `name`, `symbol` and `uri` we need to add additional metadata fields. 