### PR TITLE
anchor: support multiple unstake tickets

### DIFF
--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -22,9 +22,9 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
-# test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
+test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_drift"
-test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
+#test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_jupiter"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_openfunds"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_wsol"

--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -22,9 +22,9 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
-test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
+# test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_drift"
-#test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
+test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_jupiter"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_openfunds"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_wsol"

--- a/anchor/programs/glam/src/instructions/marinade.rs
+++ b/anchor/programs/glam/src/instructions/marinade.rs
@@ -59,7 +59,7 @@ pub fn marinade_delayed_unstake<'c: 'info, 'info>(
     ctx: Context<MarinadeDelayedUnstake>,
     msol_amount: u64,
     ticket_bump: u8,
-    ticket_id: u8,
+    ticket_id: String,
 ) -> Result<()> {
     let rent = Rent::get()?;
     let lamports = rent.minimum_balance(500); // Minimum balance to make the account rent-exempt
@@ -69,7 +69,7 @@ pub fn marinade_delayed_unstake<'c: 'info, 'info>(
     let fund_key = ctx.accounts.fund.key();
     let seeds = &[
         b"ticket".as_ref(),
-        &[ticket_id],
+        ticket_id.as_bytes(),
         fund_key.as_ref(),
         &[ticket_bump],
     ];
@@ -225,7 +225,7 @@ pub struct MarinadeDeposit<'info> {
 }
 
 #[derive(Accounts)]
-// #[instruction(ticket_id: u8)]
+// #[instruction(ticket_id: String)]
 pub struct MarinadeDelayedUnstake<'info> {
     #[account(mut)]
     pub manager: Signer<'info>,
@@ -237,8 +237,8 @@ pub struct MarinadeDelayedUnstake<'info> {
     pub treasury: SystemAccount<'info>,
 
     /// CHECK: skip
-    // #[account(mut, seeds = [b"ticket".as_ref(), &[ticket_id], fund.key().as_ref()], bump)]
-    // For some reason, the above line doesn't work, so we have to pass the bump as an instruction param
+    // #[account(mut, seeds = [b"ticket".as_ref(), ticket_id.as_bytes(), fund.key().as_ref()], bump)]
+    // The line above wll cause "Error: memory allocation failed, out of memory"
     #[account(mut)]
     pub ticket: AccountInfo<'info>,
 

--- a/anchor/programs/glam/src/instructions/marinade.rs
+++ b/anchor/programs/glam/src/instructions/marinade.rs
@@ -58,12 +58,21 @@ pub fn marinade_deposit<'c: 'info, 'info>(
 pub fn marinade_delayed_unstake<'c: 'info, 'info>(
     ctx: Context<MarinadeDelayedUnstake>,
     msol_amount: u64,
+    ticket_bump: u8,
+    ticket_id: u8,
 ) -> Result<()> {
     let rent = Rent::get()?;
     let lamports = rent.minimum_balance(500); // Minimum balance to make the account rent-exempt
 
+    msg!("ticket id: {}, ticket bump: {}", ticket_id, ticket_bump);
+
     let fund_key = ctx.accounts.fund.key();
-    let seeds = &[b"ticket".as_ref(), fund_key.as_ref(), &[ctx.bumps.ticket]];
+    let seeds = &[
+        b"ticket".as_ref(),
+        &[ticket_id],
+        fund_key.as_ref(),
+        &[ticket_bump],
+    ];
     let signer_seeds = &[&seeds[..]];
     let space = std::mem::size_of::<TicketAccountData>() as u64 + 8;
 
@@ -216,6 +225,7 @@ pub struct MarinadeDeposit<'info> {
 }
 
 #[derive(Accounts)]
+// #[instruction(ticket_id: u8)]
 pub struct MarinadeDelayedUnstake<'info> {
     #[account(mut)]
     pub manager: Signer<'info>,
@@ -227,8 +237,9 @@ pub struct MarinadeDelayedUnstake<'info> {
     pub treasury: SystemAccount<'info>,
 
     /// CHECK: skip
-    // #[account(init_if_needed, seeds = [b"ticket"], bump, payer = signer, space = 88, owner = marinade_program.key())]
-    #[account(mut, seeds = [b"ticket".as_ref(), fund.key().as_ref()], bump)]
+    // #[account(mut, seeds = [b"ticket".as_ref(), &[ticket_id], fund.key().as_ref()], bump)]
+    // For some reason, the above line doesn't work, so we have to pass the bump as an instruction param
+    #[account(mut)]
     pub ticket: AccountInfo<'info>,
 
     /// CHECK: skip
@@ -265,10 +276,8 @@ pub struct MarinadeClaim<'info> {
     #[account(mut, seeds = [b"treasury".as_ref(), fund.key().as_ref()], bump)]
     pub treasury: SystemAccount<'info>,
 
-    /// CHECK: skip
-    // #[account(init_if_needed, seeds = [b"ticket"], bump, payer = signer, space = 88, owner = marinade_program.key())]
-    #[account(mut)]
-    pub ticket: AccountInfo<'info>,
+    #[account(mut, constraint = ticket.beneficiary == treasury.key())]
+    pub ticket: Account<'info, TicketAccountData>,
 
     /// CHECK: skip
     #[account(mut)]

--- a/anchor/programs/glam/src/lib.rs
+++ b/anchor/programs/glam/src/lib.rs
@@ -106,8 +106,10 @@ pub mod glam {
     pub fn marinade_delayed_unstake(
         ctx: Context<MarinadeDelayedUnstake>,
         amount: u64,
+        bump: u8,
+        ticket_id: u8,
     ) -> Result<()> {
-        marinade::marinade_delayed_unstake(ctx, amount)
+        marinade::marinade_delayed_unstake(ctx, amount, bump, ticket_id)
     }
 
     pub fn marinade_claim(ctx: Context<MarinadeClaim>) -> Result<()> {

--- a/anchor/programs/glam/src/lib.rs
+++ b/anchor/programs/glam/src/lib.rs
@@ -107,7 +107,7 @@ pub mod glam {
         ctx: Context<MarinadeDelayedUnstake>,
         amount: u64,
         bump: u8,
-        ticket_id: u8,
+        ticket_id: String,
     ) -> Result<()> {
         marinade::marinade_delayed_unstake(ctx, amount, bump, ticket_id)
     }

--- a/anchor/src/client/marinade.ts
+++ b/anchor/src/client/marinade.ts
@@ -29,13 +29,11 @@ export class MarinadeClient {
 
   public async delayedUnstake(
     fund: PublicKey,
-    ticketId: number,
     amount: BN
   ): Promise<TransactionSignature> {
     return await this.delayedUnstakeTxBuilder(
       fund,
       this.base.getManager(),
-      ticketId,
       amount
     ).rpc();
   }
@@ -68,12 +66,12 @@ export class MarinadeClient {
 
   getMarinadeTicketPDA(
     fundPDA: PublicKey,
-    ticketId: number
+    ticketId: string
   ): [PublicKey, number] {
     return PublicKey.findProgramAddressSync(
       [
         anchor.utils.bytes.utf8.encode("ticket"),
-        Uint8Array.from([ticketId % 256]),
+        anchor.utils.bytes.utf8.encode(ticketId),
         fundPDA.toBuffer()
       ],
       this.base.programId
@@ -164,11 +162,13 @@ export class MarinadeClient {
   delayedUnstakeTxBuilder(
     fund: PublicKey,
     manager: PublicKey,
-    ticketId: number,
     amount: BN
   ): any /* MethodsBuilder<Glam, ?> */ {
-    const treasury = this.base.getTreasuryPDA(fund);
+    // Use timestamp as ticket ID
+    const ticketId = Date.now().toString();
     const [ticket, bump] = this.getMarinadeTicketPDA(fund, ticketId);
+
+    const treasury = this.base.getTreasuryPDA(fund);
     const marinadeState = this.getMarinadeState();
     const treasuryMsolAta = this.base.getTreasuryAta(
       fund,
@@ -252,13 +252,11 @@ export class MarinadeClient {
   public async delayedUnstakeTx(
     fund: PublicKey,
     manager: PublicKey,
-    ticketId: number,
     amount: BN
   ): Promise<Transaction> {
     return await this.delayedUnstakeTxBuilder(
       fund,
       manager,
-      ticketId,
       amount
     ).transaction();
   }

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -769,7 +769,7 @@
         },
         {
           "name": "ticketId",
-          "type": "u8"
+          "type": "string"
         }
       ]
     },

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -762,6 +762,14 @@
         {
           "name": "amount",
           "type": "u64"
+        },
+        {
+          "name": "bump",
+          "type": "u8"
+        },
+        {
+          "name": "ticketId",
+          "type": "u8"
         }
       ]
     },

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -762,6 +762,14 @@ export type Glam = {
         {
           "name": "amount",
           "type": "u64"
+        },
+        {
+          "name": "bump",
+          "type": "u8"
+        },
+        {
+          "name": "ticketId",
+          "type": "u8"
         }
       ]
     },
@@ -3842,6 +3850,14 @@ export const IDL: Glam = {
         {
           "name": "amount",
           "type": "u64"
+        },
+        {
+          "name": "bump",
+          "type": "u8"
+        },
+        {
+          "name": "ticketId",
+          "type": "u8"
         }
       ]
     },

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -769,7 +769,7 @@ export type Glam = {
         },
         {
           "name": "ticketId",
-          "type": "u8"
+          "type": "string"
         }
       ]
     },
@@ -3857,7 +3857,7 @@ export const IDL: Glam = {
         },
         {
           "name": "ticketId",
-          "type": "u8"
+          "type": "string"
         }
       ]
     },

--- a/anchor/tests/glam_staking.spec.ts
+++ b/anchor/tests/glam_staking.spec.ts
@@ -9,12 +9,12 @@ const msol = new PublicKey("mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So");
 describe("glam_staking", () => {
   const glamClient = new GlamClient();
   let fundPDA;
-  it("Create fund", async () => {
+
+  it("Create fund with 100 SOLs in treasury", async () => {
     const fundData = await createFundForTest(glamClient);
     fundPDA = fundData.fundPDA;
 
     const connection = glamClient.provider.connection;
-    // air drop to treasury and delay 1s for confirmation
     const airdropTx = await connection.requestAirdrop(
       fundData.treasuryPDA,
       100_000_000_000
@@ -25,7 +25,7 @@ describe("glam_staking", () => {
     });
   });
 
-  it("Marinade desposit", async () => {
+  it("Marinade desposit: stake 10 SOLs twice", async () => {
     try {
       let tx = await glamClient.marinade.stake(fundPDA, new anchor.BN(1e10));
       console.log("Stake #1:", tx);
@@ -38,7 +38,7 @@ describe("glam_staking", () => {
     }
   });
 
-  it("Liquid unstake", async () => {
+  it("Liquid unstake 1 mSOL", async () => {
     try {
       const tx = await glamClient.marinade.liquidUnstake(
         fundPDA,
@@ -51,18 +51,16 @@ describe("glam_staking", () => {
     }
   });
 
-  it("Order unstake", async () => {
+  it("Order unstake 1 mSOL twice", async () => {
     try {
       let tx = await glamClient.marinade.delayedUnstake(
         fundPDA,
-        0,
         new anchor.BN(1e9)
       );
       console.log("Delayed unstake #0:", tx);
 
       tx = await glamClient.marinade.delayedUnstake(
         fundPDA,
-        1,
         new anchor.BN(1e9)
       );
       console.log("Delayed unstake #1:", tx);
@@ -108,7 +106,7 @@ describe("glam_staking", () => {
       console.log("Error", error);
       throw error;
     }
-  }, 35_000);
+  }, 15_000);
 
   it("Search tickets after claim", async () => {
     const tickets = await glamClient.marinade.getExistingTickets(fundPDA);

--- a/anchor/tests/glam_staking.spec.ts
+++ b/anchor/tests/glam_staking.spec.ts
@@ -2,11 +2,13 @@ import * as anchor from "@coral-xyz/anchor";
 
 import { createFundForTest, sleep } from "./setup";
 import { GlamClient } from "../src";
+import { PublicKey } from "@solana/web3.js";
+
+const msol = new PublicKey("mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So");
 
 describe("glam_staking", () => {
   const glamClient = new GlamClient();
   let fundPDA;
-
   it("Create fund", async () => {
     const fundData = await createFundForTest(glamClient);
     fundPDA = fundData.fundPDA;
@@ -53,34 +55,63 @@ describe("glam_staking", () => {
     try {
       let tx = await glamClient.marinade.delayedUnstake(
         fundPDA,
+        0,
+        new anchor.BN(1e9)
+      );
+      console.log("Delayed unstake #0:", tx);
+
+      tx = await glamClient.marinade.delayedUnstake(
+        fundPDA,
+        1,
         new anchor.BN(1e9)
       );
       console.log("Delayed unstake #1:", tx);
-
-      // tx = await glamClient.marinade.delayedUnstake(
-      //   fundPDA,
-      //   new anchor.BN(1e9)
-      // );
-      // console.log("Delayed unstake #2:", tx);
     } catch (error) {
       console.log("Error", error);
       throw error;
     }
   });
 
-  it("Claim", async () => {
+  it("Search tickets before claim", async () => {
+    const tickets = await glamClient.marinade.getExistingTickets(fundPDA);
+    console.log("Tickets", tickets);
+    expect(tickets.length).toBe(2);
+  });
+
+  it("Claim ticket #0", async () => {
     // wait for 30s so that the ticket is ready to be claimed
     await sleep(30_000);
-
-    const ticketPda = glamClient.marinade.getMarinadeTicketPDA(fundPDA);
-    console.log("ticketPda", ticketPda.toBase58());
-
+    const tickets = await glamClient.marinade.getExistingTickets(fundPDA);
     try {
-      const tx = await glamClient.marinade.delayedUnstakeClaim(fundPDA);
+      const tx = await glamClient.marinade.delayedUnstakeClaim(
+        fundPDA,
+        tickets[0]
+      );
       console.log("Claim delayed unstake:", tx);
     } catch (error) {
       console.log("Error", error);
       throw error;
     }
   }, 35_000);
+
+  it("Claim ticket #1", async () => {
+    const tickets = await glamClient.marinade.getExistingTickets(fundPDA);
+    expect(tickets.length).toBe(1);
+
+    try {
+      const tx = await glamClient.marinade.delayedUnstakeClaim(
+        fundPDA,
+        tickets[0]
+      );
+      console.log("Claim delayed unstake:", tx);
+    } catch (error) {
+      console.log("Error", error);
+      throw error;
+    }
+  }, 35_000);
+
+  it("Search tickets after claim", async () => {
+    const tickets = await glamClient.marinade.getExistingTickets(fundPDA);
+    expect(tickets.length).toBe(0);
+  });
 });

--- a/api/src/routers/fund.ts
+++ b/api/src/routers/fund.ts
@@ -71,6 +71,13 @@ router.get("/fund/:pubkey/perf", async (req, res) => {
   );
 });
 
+router.get("/fund/:pubkey/tickets", async (req, res) => {
+  const fund = validatePubkey(req.params.pubkey);
+  const tickets = await req.client.marinade.getExistingTickets(fund);
+  res.set("content-type", "application/json");
+  res.send({ tickets });
+});
+
 router.get("/metadata/:pubkey", async (req, res) => {
   const pubkey = validatePubkey(req.params.pubkey);
   if (!pubkey) {


### PR DESCRIPTION
1. Use a unique ticket id to create different ticket PDAs
2. `getExistingTickets` returns a list of ticket PDAs that can be claimed later on

This allows fund manager to order as many delayed unstakes as they want.
