### PR TITLE
anchor: access control impl

### DIFF
--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -21,8 +21,8 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-#test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
-test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
+test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
+# test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_drift"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_jupiter"

--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -21,8 +21,8 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
-# test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
+#test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
+test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_drift"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_jupiter"

--- a/anchor/programs/glam/src/constants.rs
+++ b/anchor/programs/glam/src/constants.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use solana_program::pubkey;
 
 #[constant]
 pub const SEED: &str = "anchor";
@@ -8,3 +9,5 @@ pub const MAX_SHARE_CLASSES: usize = 3;
 pub const MAX_FUND_NAME: usize = 50;
 pub const MAX_FUND_SYMBOL: usize = 20;
 pub const MAX_FUND_URI: usize = 100;
+
+pub const WSOL: Pubkey = pubkey!("So11111111111111111111111111111111111111112");

--- a/anchor/programs/glam/src/instructions/manager.rs
+++ b/anchor/programs/glam/src/instructions/manager.rs
@@ -100,7 +100,7 @@ pub fn initialize_fund_handler<'c: 'info, 'info>(
             },
         },
         EngineField {
-            name: EngineFieldName::Permissions,
+            name: EngineFieldName::Acls,
             value: EngineFieldValue::VecAcl { val: Vec::new() },
         },
     ]];

--- a/anchor/programs/glam/src/state/accounts.rs
+++ b/anchor/programs/glam/src/state/accounts.rs
@@ -10,7 +10,7 @@ pub enum EngineFieldName {
     IsEnabled,
     Assets,
     AssetsWeights,
-    Permissions,
+    Acls,
     ShareClassAllowlist,
     ShareClassBlocklist,
 }

--- a/anchor/programs/glam/src/state/accounts.rs
+++ b/anchor/programs/glam/src/state/accounts.rs
@@ -10,9 +10,9 @@ pub enum EngineFieldName {
     IsEnabled,
     Assets,
     AssetsWeights,
-    Acls,
     ShareClassAllowlist,
     ShareClassBlocklist,
+    Acls,
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]
@@ -121,6 +121,21 @@ impl FundAccount {
                 EngineFieldName::AssetsWeights => {
                     return match value {
                         EngineFieldValue::VecU32 { val: v } => Some(v),
+                        _ => None,
+                    };
+                }
+                _ => { /* ignore */ }
+            }
+        }
+        return None;
+    }
+
+    pub fn acls(&self) -> Option<&Vec<Acl>> {
+        for EngineField { name, value } in &self.params[0] {
+            match name {
+                EngineFieldName::Acls => {
+                    return match value {
+                        EngineFieldValue::VecAcl { val: v } => Some(v),
                         _ => None,
                     };
                 }

--- a/anchor/programs/glam/src/state/accounts.rs
+++ b/anchor/programs/glam/src/state/accounts.rs
@@ -9,6 +9,8 @@ pub enum EngineFieldName {
     IsEnabled,
     Assets,
     AssetsWeights,
+    Managers,
+    Traders,
     ShareClassAllowlist,
     ShareClassBlocklist,
 }

--- a/anchor/programs/glam/src/state/accounts.rs
+++ b/anchor/programs/glam/src/state/accounts.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 
+use super::acl::*;
 use super::model::*;
 use super::openfunds::*;
 
@@ -9,8 +10,7 @@ pub enum EngineFieldName {
     IsEnabled,
     Assets,
     AssetsWeights,
-    Managers,
-    Traders,
+    Permissions,
     ShareClassAllowlist,
     ShareClassBlocklist,
 }
@@ -33,6 +33,7 @@ pub enum EngineFieldValue {
     Timestamp { val: i64 },
     VecPubkey { val: Vec<Pubkey> },
     VecU32 { val: Vec<u32> },
+    VecAcl { val: Vec<Acl> },
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]

--- a/anchor/programs/glam/src/state/acl.rs
+++ b/anchor/programs/glam/src/state/acl.rs
@@ -1,0 +1,67 @@
+use anchor_lang::prelude::*;
+
+use super::{
+    accounts::{EngineField, EngineFieldName, EngineFieldValue},
+    FundAccount,
+};
+
+#[error_code]
+pub enum AccessError {
+    #[msg("Signer not authorized to perform this action")]
+    NotAuthorized,
+}
+
+#[derive(AnchorDeserialize, AnchorSerialize, Clone, PartialEq, Debug)]
+pub enum Permission {
+    FundUpdate,
+    DriftDeposit,
+    DriftWithdraw,
+    MarinadeStake,
+    MarinadeUnstake, // Order delayed unstake + claim ticket
+    MarinadeLiquidUnstake,
+    JupiterSwapFundAssets,
+    JupiterSwapAnyAsset,
+    WSolWrap,
+    WSolUnwrap,
+}
+
+#[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]
+pub struct Acl {
+    pub pubkey: Pubkey,
+    pub permissions: Vec<Permission>,
+}
+
+pub fn check_access(fund: &FundAccount, signer: &Pubkey, permission: Permission) -> Result<()> {
+    if fund.manager == *signer {
+        return Ok(());
+    }
+
+    msg!(
+        "Checking access for signer {:?} on permission {:?}",
+        signer,
+        permission
+    );
+
+    let engine_fields = &fund.params[0];
+    let mut authorized = false;
+    for EngineField { name, value } in engine_fields {
+        match name {
+            EngineFieldName::Permissions => {
+                if let EngineFieldValue::VecAcl { val } = &value {
+                    for acl in val {
+                        if acl.pubkey == *signer && acl.permissions.contains(&permission) {
+                            authorized = true
+                        }
+                        break;
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+    if authorized {
+        Ok(())
+    } else {
+        Err(AccessError::NotAuthorized.into())
+    }
+}

--- a/anchor/programs/glam/src/state/acl.rs
+++ b/anchor/programs/glam/src/state/acl.rs
@@ -4,7 +4,7 @@ use super::FundAccount;
 
 #[error_code]
 pub enum AccessError {
-    #[msg("Signer not authorized to perform this action")]
+    #[msg("Signer is not authorized")]
     NotAuthorized,
 }
 

--- a/anchor/programs/glam/src/state/acl.rs
+++ b/anchor/programs/glam/src/state/acl.rs
@@ -46,7 +46,7 @@ pub fn check_access(fund: &FundAccount, signer: &Pubkey, permission: Permission)
     let mut authorized = false;
     for EngineField { name, value } in engine_fields {
         match name {
-            EngineFieldName::Permissions => {
+            EngineFieldName::Acls => {
                 if let EngineFieldValue::VecAcl { val } = &value {
                     for acl in val {
                         if acl.pubkey == *signer && acl.permissions.contains(&permission) {

--- a/anchor/programs/glam/src/state/mod.rs
+++ b/anchor/programs/glam/src/state/mod.rs
@@ -9,3 +9,6 @@ pub use accounts::*;
 
 pub mod assets;
 pub use assets::*;
+
+pub mod acl;
+pub use acl::*;

--- a/anchor/programs/glam/src/state/model/model.rs
+++ b/anchor/programs/glam/src/state/model/model.rs
@@ -20,10 +20,6 @@ pub struct FundModel {
     pub assets: Vec<Pubkey>,
     pub assets_weights: Vec<u32>,
 
-    // Roles
-    pub managers: Option<Vec<Pubkey>>, // current manager excluded in this list
-    pub traders: Option<Vec<Pubkey>>,
-
     // Relationships
     pub share_classes: Vec<ShareClassModel>,
     pub company: Option<CompanyModel>,

--- a/anchor/programs/glam/src/state/model/model.rs
+++ b/anchor/programs/glam/src/state/model/model.rs
@@ -1,5 +1,7 @@
 use anchor_lang::prelude::*;
 
+use super::super::acl::*;
+
 // Fund
 //
 // Implemented:
@@ -27,6 +29,9 @@ pub struct FundModel {
     pub company: Option<CompanyModel>,
     pub manager: Option<ManagerModel>,
     pub created: Option<CreatedModel>,
+
+    // ACLs
+    pub acls: Option<Vec<Acl>>,
 
     // Openfunds
     pub is_raw_openfunds: Option<bool>,

--- a/anchor/programs/glam/src/state/model/model.rs
+++ b/anchor/programs/glam/src/state/model/model.rs
@@ -18,6 +18,10 @@ pub struct FundModel {
     pub assets: Vec<Pubkey>,
     pub assets_weights: Vec<u32>,
 
+    // Roles
+    pub managers: Option<Vec<Pubkey>>, // current manager excluded in this list
+    pub traders: Option<Vec<Pubkey>>,
+
     // Relationships
     pub share_classes: Vec<ShareClassModel>,
     pub company: Option<CompanyModel>,

--- a/anchor/programs/glam/src/state/model/model.rs
+++ b/anchor/programs/glam/src/state/model/model.rs
@@ -27,7 +27,7 @@ pub struct FundModel {
     pub created: Option<CreatedModel>,
 
     // ACLs
-    pub acls: Option<Vec<Acl>>,
+    pub acls: Vec<Acl>,
 
     // Openfunds
     pub is_raw_openfunds: Option<bool>,

--- a/anchor/src/client/base.ts
+++ b/anchor/src/client/base.ts
@@ -308,9 +308,6 @@ export class BaseClient {
   enrichFundModelInitialize(fund: FundModel): FundModel {
     let fundModel = this.getFundModel(fund);
 
-    fundModel.managers = [];
-    fundModel.traders = [];
-
     // createdKey = hash fund name and get first 8 bytes
     const createdKey = [
       ...Buffer.from(
@@ -332,7 +329,9 @@ export class BaseClient {
       fundModel.name = fundModel.name || shareClass.name;
 
       fundModel.rawOpenfunds.fundCurrency =
-        shareClass.rawOpenfunds?.shareClassCurrency || null;
+        fundModel.rawOpenfunds?.fundCurrency ||
+        shareClass.rawOpenfunds?.shareClassCurrency ||
+        null;
     } else {
       // fund with multiple share classes
       // TODO
@@ -384,8 +383,6 @@ export class BaseClient {
 
     const shareClasses = fundModel.shareClasses;
     fundModel.shareClasses = [];
-
-    console.log("Creating fund", fundModel);
 
     const txSig = await this.program.methods
       .initialize(fundModel)

--- a/anchor/src/client/base.ts
+++ b/anchor/src/client/base.ts
@@ -477,7 +477,7 @@ export class BaseClient {
       ...this.getOpenfundsFromAccounts(fundAccount, openfundsAccount),
     };
 
-    fund.acls = fundAccount.params[0][2].value.vecAcl.val;
+    fund.acls = fundAccount.params[0][2].value.vecAcl?.val;
 
     // Add data from fund params to share classes
     fund.shareClasses = fund.shareClasses.map((shareClass: any, i: number) => {

--- a/anchor/src/client/base.ts
+++ b/anchor/src/client/base.ts
@@ -231,7 +231,7 @@ export class BaseClient {
     const createdKey = fundModel?.created?.key || [
       ...Buffer.from(
         anchor.utils.sha256.hash(this.getFundName(fundModel))
-      ).slice(0, 8),
+      ).subarray(0, 8),
     ];
 
     const manager = this.getManager();
@@ -308,11 +308,14 @@ export class BaseClient {
   enrichFundModelInitialize(fund: FundModel): FundModel {
     let fundModel = this.getFundModel(fund);
 
+    fundModel.managers = [];
+    fundModel.traders = [];
+
     // createdKey = hash fund name and get first 8 bytes
     const createdKey = [
       ...Buffer.from(
         anchor.utils.sha256.hash(this.getFundName(fundModel))
-      ).slice(0, 8),
+      ).subarray(0, 8),
     ];
     fundModel.created = {
       key: createdKey,
@@ -329,9 +332,7 @@ export class BaseClient {
       fundModel.name = fundModel.name || shareClass.name;
 
       fundModel.rawOpenfunds.fundCurrency =
-        fundModel.rawOpenfunds?.fundCurrency ||
-        shareClass.rawOpenfunds?.shareClassCurrency ||
-        null;
+        shareClass.rawOpenfunds?.shareClassCurrency || null;
     } else {
       // fund with multiple share classes
       // TODO
@@ -383,6 +384,8 @@ export class BaseClient {
 
     const shareClasses = fundModel.shareClasses;
     fundModel.shareClasses = [];
+
+    console.log("Creating fund", fundModel);
 
     const txSig = await this.program.methods
       .initialize(fundModel)

--- a/anchor/src/client/base.ts
+++ b/anchor/src/client/base.ts
@@ -480,6 +480,8 @@ export class BaseClient {
       ...this.getOpenfundsFromAccounts(fundAccount, openfundsAccount),
     };
 
+    fund.acls = fundAccount.params[0][2].value.vecAcl.val;
+
     // Add data from fund params to share classes
     fund.shareClasses = fund.shareClasses.map((shareClass: any, i: number) => {
       const fund_param_idx = 1 + i;

--- a/anchor/src/client/jupiter.ts
+++ b/anchor/src/client/jupiter.ts
@@ -268,7 +268,7 @@ export class JupiterClient {
               treasury: treasuryPda,
               treasuryWsolAta,
               wsolMint: inputMint,
-              manager,
+              signer: manager,
             })
             .instruction()
         );

--- a/anchor/src/client/wsol.ts
+++ b/anchor/src/client/wsol.ts
@@ -3,6 +3,7 @@ import {
   PublicKey,
   VersionedTransaction,
   TransactionSignature,
+  Keypair,
 } from "@solana/web3.js";
 
 import { BaseClient, ApiTxOptions } from "./base";
@@ -18,15 +19,19 @@ export class WSolClient {
 
   public async wrap(
     fund: PublicKey,
-    amount: BN
+    amount: BN,
+    signer?: Keypair
   ): Promise<TransactionSignature> {
-    const tx = await this.wrapTx(fund, amount, {});
-    return await this.base.sendAndConfirm(tx);
+    const tx = await this.wrapTx(fund, amount, { signer: signer?.publicKey });
+    return await this.base.sendAndConfirm(tx, signer);
   }
 
-  public async unwrap(fund: PublicKey): Promise<TransactionSignature> {
-    const tx = await this.unwrapTx(fund, {});
-    return await this.base.sendAndConfirm(tx);
+  public async unwrap(
+    fund: PublicKey,
+    signer?: Keypair
+  ): Promise<TransactionSignature> {
+    const tx = await this.unwrapTx(fund, { signer: signer?.publicKey });
+    return await this.base.sendAndConfirm(tx, signer);
   }
 
   /*
@@ -49,7 +54,7 @@ export class WSolClient {
         treasury,
         treasuryWsolAta,
         wsolMint,
-        manager,
+        signer: manager,
       })
       .transaction();
 
@@ -74,7 +79,7 @@ export class WSolClient {
         treasury,
         treasuryWsolAta,
         wsolMint,
-        manager,
+        signer: manager,
       })
       .transaction();
 

--- a/anchor/src/models.ts
+++ b/anchor/src/models.ts
@@ -23,6 +23,7 @@ export const FundModel = class<FundModel> {
       ...partial,
       assets: obj.assets || [],
       assetsWeights: obj.assetsWeights || [],
+      acls: obj.acls || [],
       shareClasses: obj.shareClasses
         ? obj.shareClasses.map(
             (shareClass: any) =>

--- a/anchor/src/models.ts
+++ b/anchor/src/models.ts
@@ -13,6 +13,8 @@ export const FundModel = class<FundModel> {
       isEnabled: null,
       created: null,
       isRawOpenfunds: null,
+      managers: [],
+      traders: [],
     };
     for (const key in partial) {
       partial[key] = obj[key] || null;

--- a/anchor/src/models.ts
+++ b/anchor/src/models.ts
@@ -13,8 +13,6 @@ export const FundModel = class<FundModel> {
       isEnabled: null,
       created: null,
       isRawOpenfunds: null,
-      managers: [],
-      traders: [],
     };
     for (const key in partial) {
       partial[key] = obj[key] || null;

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -941,7 +941,7 @@
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         },
@@ -992,7 +992,7 @@
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         },
@@ -1230,10 +1230,8 @@
           {
             "name": "acls",
             "type": {
-              "option": {
-                "vec": {
-                  "defined": "Acl"
-                }
+              "vec": {
+                "defined": "Acl"
               }
             }
           },
@@ -1837,13 +1835,13 @@
             "name": "AssetsWeights"
           },
           {
-            "name": "Acls"
-          },
-          {
             "name": "ShareClassAllowlist"
           },
           {
             "name": "ShareClassBlocklist"
+          },
+          {
+            "name": "Acls"
           }
         ]
       }
@@ -2015,9 +2013,6 @@
       "type": {
         "kind": "enum",
         "variants": [
-          {
-            "name": "FundUpdate"
-          },
           {
             "name": "DriftDeposit"
           },

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -1196,22 +1196,6 @@
             }
           },
           {
-            "name": "managers",
-            "type": {
-              "option": {
-                "vec": "publicKey"
-              }
-            }
-          },
-          {
-            "name": "traders",
-            "type": {
-              "option": {
-                "vec": "publicKey"
-              }
-            }
-          },
-          {
             "name": "shareClasses",
             "type": {
               "vec": {
@@ -1853,7 +1837,7 @@
             "name": "AssetsWeights"
           },
           {
-            "name": "Permissions"
+            "name": "Acls"
           },
           {
             "name": "ShareClassAllowlist"

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -1176,6 +1176,22 @@
             }
           },
           {
+            "name": "managers",
+            "type": {
+              "option": {
+                "vec": "publicKey"
+              }
+            }
+          },
+          {
+            "name": "traders",
+            "type": {
+              "option": {
+                "vec": "publicKey"
+              }
+            }
+          },
+          {
             "name": "shareClasses",
             "type": {
               "vec": {
@@ -1805,6 +1821,12 @@
           },
           {
             "name": "AssetsWeights"
+          },
+          {
+            "name": "Managers"
+          },
+          {
+            "name": "Traders"
           },
           {
             "name": "ShareClassAllowlist"

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -99,7 +99,7 @@
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         }
@@ -1129,6 +1129,26 @@
       }
     },
     {
+      "name": "Acl",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "permissions",
+            "type": {
+              "vec": {
+                "defined": "Permission"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "FundModel",
       "type": {
         "kind": "struct",
@@ -1220,6 +1240,16 @@
             "type": {
               "option": {
                 "defined": "CreatedModel"
+              }
+            }
+          },
+          {
+            "name": "acls",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Acl"
+                }
               }
             }
           },
@@ -1823,10 +1853,7 @@
             "name": "AssetsWeights"
           },
           {
-            "name": "Managers"
-          },
-          {
-            "name": "Traders"
+            "name": "Permissions"
           },
           {
             "name": "ShareClassAllowlist"
@@ -1971,6 +1998,68 @@
                 }
               }
             ]
+          },
+          {
+            "name": "VecAcl",
+            "fields": [
+              {
+                "name": "val",
+                "type": {
+                  "vec": {
+                    "defined": "Acl"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "AccessError",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NotAuthorized"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permission",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "FundUpdate"
+          },
+          {
+            "name": "DriftDeposit"
+          },
+          {
+            "name": "DriftWithdraw"
+          },
+          {
+            "name": "MarinadeStake"
+          },
+          {
+            "name": "MarinadeUnstake"
+          },
+          {
+            "name": "MarinadeLiquidUnstake"
+          },
+          {
+            "name": "JupiterSwapFundAssets"
+          },
+          {
+            "name": "JupiterSwapAnyAsset"
+          },
+          {
+            "name": "WSolWrap"
+          },
+          {
+            "name": "WSolUnwrap"
           }
         ]
       }

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -941,7 +941,7 @@ export type Glam = {
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         },
@@ -992,7 +992,7 @@ export type Glam = {
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         },
@@ -1230,10 +1230,8 @@ export type Glam = {
           {
             "name": "acls",
             "type": {
-              "option": {
-                "vec": {
-                  "defined": "Acl"
-                }
+              "vec": {
+                "defined": "Acl"
               }
             }
           },
@@ -1837,13 +1835,13 @@ export type Glam = {
             "name": "AssetsWeights"
           },
           {
-            "name": "Acls"
-          },
-          {
             "name": "ShareClassAllowlist"
           },
           {
             "name": "ShareClassBlocklist"
+          },
+          {
+            "name": "Acls"
           }
         ]
       }
@@ -2015,9 +2013,6 @@ export type Glam = {
       "type": {
         "kind": "enum",
         "variants": [
-          {
-            "name": "FundUpdate"
-          },
           {
             "name": "DriftDeposit"
           },
@@ -4142,7 +4137,7 @@ export const IDL: Glam = {
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         },
@@ -4193,7 +4188,7 @@ export const IDL: Glam = {
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         },
@@ -4431,10 +4426,8 @@ export const IDL: Glam = {
           {
             "name": "acls",
             "type": {
-              "option": {
-                "vec": {
-                  "defined": "Acl"
-                }
+              "vec": {
+                "defined": "Acl"
               }
             }
           },
@@ -5038,13 +5031,13 @@ export const IDL: Glam = {
             "name": "AssetsWeights"
           },
           {
-            "name": "Acls"
-          },
-          {
             "name": "ShareClassAllowlist"
           },
           {
             "name": "ShareClassBlocklist"
+          },
+          {
+            "name": "Acls"
           }
         ]
       }
@@ -5216,9 +5209,6 @@ export const IDL: Glam = {
       "type": {
         "kind": "enum",
         "variants": [
-          {
-            "name": "FundUpdate"
-          },
           {
             "name": "DriftDeposit"
           },

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -1196,22 +1196,6 @@ export type Glam = {
             }
           },
           {
-            "name": "managers",
-            "type": {
-              "option": {
-                "vec": "publicKey"
-              }
-            }
-          },
-          {
-            "name": "traders",
-            "type": {
-              "option": {
-                "vec": "publicKey"
-              }
-            }
-          },
-          {
             "name": "shareClasses",
             "type": {
               "vec": {
@@ -1853,7 +1837,7 @@ export type Glam = {
             "name": "AssetsWeights"
           },
           {
-            "name": "Permissions"
+            "name": "Acls"
           },
           {
             "name": "ShareClassAllowlist"
@@ -4413,22 +4397,6 @@ export const IDL: Glam = {
             }
           },
           {
-            "name": "managers",
-            "type": {
-              "option": {
-                "vec": "publicKey"
-              }
-            }
-          },
-          {
-            "name": "traders",
-            "type": {
-              "option": {
-                "vec": "publicKey"
-              }
-            }
-          },
-          {
             "name": "shareClasses",
             "type": {
               "vec": {
@@ -5070,7 +5038,7 @@ export const IDL: Glam = {
             "name": "AssetsWeights"
           },
           {
-            "name": "Permissions"
+            "name": "Acls"
           },
           {
             "name": "ShareClassAllowlist"

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -99,7 +99,7 @@ export type Glam = {
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         }
@@ -1129,6 +1129,26 @@ export type Glam = {
       }
     },
     {
+      "name": "Acl",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "permissions",
+            "type": {
+              "vec": {
+                "defined": "Permission"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "FundModel",
       "type": {
         "kind": "struct",
@@ -1220,6 +1240,16 @@ export type Glam = {
             "type": {
               "option": {
                 "defined": "CreatedModel"
+              }
+            }
+          },
+          {
+            "name": "acls",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Acl"
+                }
               }
             }
           },
@@ -1823,10 +1853,7 @@ export type Glam = {
             "name": "AssetsWeights"
           },
           {
-            "name": "Managers"
-          },
-          {
-            "name": "Traders"
+            "name": "Permissions"
           },
           {
             "name": "ShareClassAllowlist"
@@ -1971,6 +1998,68 @@ export type Glam = {
                 }
               }
             ]
+          },
+          {
+            "name": "VecAcl",
+            "fields": [
+              {
+                "name": "val",
+                "type": {
+                  "vec": {
+                    "defined": "Acl"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "AccessError",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NotAuthorized"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permission",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "FundUpdate"
+          },
+          {
+            "name": "DriftDeposit"
+          },
+          {
+            "name": "DriftWithdraw"
+          },
+          {
+            "name": "MarinadeStake"
+          },
+          {
+            "name": "MarinadeUnstake"
+          },
+          {
+            "name": "MarinadeLiquidUnstake"
+          },
+          {
+            "name": "JupiterSwapFundAssets"
+          },
+          {
+            "name": "JupiterSwapAnyAsset"
+          },
+          {
+            "name": "WSolWrap"
+          },
+          {
+            "name": "WSolUnwrap"
           }
         ]
       }
@@ -3227,7 +3316,7 @@ export const IDL: Glam = {
           "isSigner": false
         },
         {
-          "name": "manager",
+          "name": "signer",
           "isMut": true,
           "isSigner": true
         }
@@ -4257,6 +4346,26 @@ export const IDL: Glam = {
       }
     },
     {
+      "name": "Acl",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "permissions",
+            "type": {
+              "vec": {
+                "defined": "Permission"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "FundModel",
       "type": {
         "kind": "struct",
@@ -4348,6 +4457,16 @@ export const IDL: Glam = {
             "type": {
               "option": {
                 "defined": "CreatedModel"
+              }
+            }
+          },
+          {
+            "name": "acls",
+            "type": {
+              "option": {
+                "vec": {
+                  "defined": "Acl"
+                }
               }
             }
           },
@@ -4951,10 +5070,7 @@ export const IDL: Glam = {
             "name": "AssetsWeights"
           },
           {
-            "name": "Managers"
-          },
-          {
-            "name": "Traders"
+            "name": "Permissions"
           },
           {
             "name": "ShareClassAllowlist"
@@ -5099,6 +5215,68 @@ export const IDL: Glam = {
                 }
               }
             ]
+          },
+          {
+            "name": "VecAcl",
+            "fields": [
+              {
+                "name": "val",
+                "type": {
+                  "vec": {
+                    "defined": "Acl"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "AccessError",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NotAuthorized"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permission",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "FundUpdate"
+          },
+          {
+            "name": "DriftDeposit"
+          },
+          {
+            "name": "DriftWithdraw"
+          },
+          {
+            "name": "MarinadeStake"
+          },
+          {
+            "name": "MarinadeUnstake"
+          },
+          {
+            "name": "MarinadeLiquidUnstake"
+          },
+          {
+            "name": "JupiterSwapFundAssets"
+          },
+          {
+            "name": "JupiterSwapAnyAsset"
+          },
+          {
+            "name": "WSolWrap"
+          },
+          {
+            "name": "WSolUnwrap"
           }
         ]
       }

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -1176,6 +1176,22 @@ export type Glam = {
             }
           },
           {
+            "name": "managers",
+            "type": {
+              "option": {
+                "vec": "publicKey"
+              }
+            }
+          },
+          {
+            "name": "traders",
+            "type": {
+              "option": {
+                "vec": "publicKey"
+              }
+            }
+          },
+          {
             "name": "shareClasses",
             "type": {
               "vec": {
@@ -1805,6 +1821,12 @@ export type Glam = {
           },
           {
             "name": "AssetsWeights"
+          },
+          {
+            "name": "Managers"
+          },
+          {
+            "name": "Traders"
           },
           {
             "name": "ShareClassAllowlist"
@@ -4282,6 +4304,22 @@ export const IDL: Glam = {
             }
           },
           {
+            "name": "managers",
+            "type": {
+              "option": {
+                "vec": "publicKey"
+              }
+            }
+          },
+          {
+            "name": "traders",
+            "type": {
+              "option": {
+                "vec": "publicKey"
+              }
+            }
+          },
+          {
             "name": "shareClasses",
             "type": {
               "vec": {
@@ -4911,6 +4949,12 @@ export const IDL: Glam = {
           },
           {
             "name": "AssetsWeights"
+          },
+          {
+            "name": "Managers"
+          },
+          {
+            "name": "Traders"
           },
           {
             "name": "ShareClassAllowlist"

--- a/anchor/tests/glam_crud.spec.ts
+++ b/anchor/tests/glam_crud.spec.ts
@@ -16,17 +16,9 @@ describe("glam_crud", () => {
     expect(fund.shareClasses.length).toEqual(1);
     expect(fund.shareClasses[0].allowlist).toEqual([glamClient.getManager()]);
     expect(fund.shareClasses[0].blocklist).toEqual([]);
-    // expect(fund.assets.length).toEqual(3);
-    // expect(fund.isEnabled).toEqual(true);
-
-    // const metadata = await getTokenMetadata(provider.connection, sharePDA);
-    // const { image_uri } = Object.fromEntries(metadata!.additionalMetadata);
-    // expect(metadata?.symbol).toEqual("GBTC.A");
-    // expect(metadata?.uri).toEqual(getMetadataUri(sharePDA));
-    // expect(image_uri).toEqual(getImageUri(sharePDA));
   });
 
-  it("Update fund", async () => {
+  it("Update fund name", async () => {
     const newName = "Updated fund name";
     const updatedFund = glamClient.getFundModel({
       name: newName,
@@ -43,6 +35,39 @@ describe("glam_crud", () => {
     expect(fund.name).toEqual(newName);
   });
 
+  it("Update fund to assign new manager", async () => {
+    const newManager = Keypair.generate();
+    let updatedFund = glamClient.getFundModel({
+      managers: [glamClient.getManager(), newManager.publicKey],
+    });
+
+    await glamClient.program.methods
+      .update(updatedFund)
+      .accounts({
+        fund: fundPDA,
+        manager: glamClient.getManager(),
+      })
+      .rpc();
+
+    // New manager should be able to update fund info
+    const newName = "Updated fund name by new manager";
+    updatedFund = glamClient.getFundModel({
+      name: newName,
+    });
+
+    await glamClient.program.methods
+      .update(updatedFund)
+      .accounts({
+        fund: fundPDA,
+        manager: newManager.publicKey,
+      })
+      .signers([newManager])
+      .rpc();
+    const fund = await glamClient.program.account.fundAccount.fetch(fundPDA);
+    expect(fund.name).toEqual(newName);
+  });
+
+  /*
   it("Update manager", async () => {
     const manager = glamClient.getManager();
     const newManager = Keypair.generate();
@@ -79,7 +104,6 @@ describe("glam_crud", () => {
       },
     });
 
-    /* old manager can NOT update back */
     try {
       const txId = await glamClient.program.methods
         .update(updatedFund2)
@@ -93,7 +117,6 @@ describe("glam_crud", () => {
       expect(err.message).toContain("not authorized");
     }
 
-    /* new manager CAN update back */
     try {
       const txId = await glamClient.program.methods
         .update(updatedFund2)
@@ -110,6 +133,7 @@ describe("glam_crud", () => {
     fund = await glamClient.program.account.fundAccount.fetch(fundPDA);
     expect(fund.manager.toString()).toEqual(manager.toString());
   });
+  */
 
   /*
   it("Close fund", async () => {

--- a/anchor/tests/glam_crud.spec.ts
+++ b/anchor/tests/glam_crud.spec.ts
@@ -105,7 +105,7 @@ describe("glam_crud", () => {
     } catch (e) {
       console.log("Error", e);
       const expectedError = e.logs.some((log) =>
-        log.includes("Signer not authorized to perform this action")
+        log.includes("Signer is not authorized")
       );
       expect(expectedError).toBeTruthy();
     }
@@ -123,9 +123,7 @@ describe("glam_crud", () => {
         .signers([key1])
         .rpc();
     } catch (e) {
-      expect(e.error.errorMessage).toEqual(
-        "Signer not authorized to perform this action"
-      );
+      expect(e.error.errorMessage).toEqual("Signer is not authorized");
     }
   });
 

--- a/anchor/tests/glam_investor.spec.ts
+++ b/anchor/tests/glam_investor.spec.ts
@@ -21,15 +21,8 @@ import {
   createTransferCheckedInstruction,
 } from "@solana/spl-token";
 
-import { fundTestExample, createFundForTest } from "./setup";
+import { fundTestExample, createFundForTest, str2seed } from "./setup";
 import { GlamClient } from "../src";
-
-const str2seed = (str: String) =>
-  Uint8Array.from(
-    Array.from(str)
-      .map((letter) => letter.charCodeAt(0))
-      .concat(new Array(32 - str.length).fill(0))
-  );
 
 describe("glam_investor", () => {
   const glamClient = new GlamClient();

--- a/anchor/tests/setup.ts
+++ b/anchor/tests/setup.ts
@@ -58,6 +58,8 @@ export const fundTestExample = {
   isEnabled: true,
   assets: [wsol, msol],
   assetsWeights: [50, 50],
+  managers: [] as PublicKey[],
+  traders: [] as PublicKey[],
   // Openfunds (Fund)
   fundDomicileAlpha2: "XS",
   legalFundNameIncludingUmbrella: "Glam Fund SOL-mSOL",

--- a/anchor/tests/setup.ts
+++ b/anchor/tests/setup.ts
@@ -12,6 +12,13 @@ export const sleep = async (ms: number) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
+export const str2seed = (str: String) =>
+  Uint8Array.from(
+    Array.from(str)
+      .map((letter) => letter.charCodeAt(0))
+      .concat(new Array(32 - str.length).fill(0))
+  );
+
 export const fundTestExample = {
   shareClasses: [
     {

--- a/anchor/tests/setup.ts
+++ b/anchor/tests/setup.ts
@@ -65,8 +65,6 @@ export const fundTestExample = {
   isEnabled: true,
   assets: [wsol, msol],
   assetsWeights: [50, 50],
-  managers: [] as PublicKey[],
-  traders: [] as PublicKey[],
   // Openfunds (Fund)
   fundDomicileAlpha2: "XS",
   legalFundNameIncludingUmbrella: "Glam Fund SOL-mSOL",


### PR DESCRIPTION
1. Defines a list of permissions as a rust enum
2. Each acl entry is a pair of `<pubkey, permissions>`
3. Stores acls in engine params: `fund.params[0][2]` (the first two indices have been used for assets and assets weights)
4. Defines a reusable `check_access` method that takes 3 params: `fund`, `signer`, and `permission`. It checks if the signer has the required permission on the fund.
5. Uses `#[access_control(...)]` to perform the authorization check.

Next: will adopt this new access control on other glam methods in a follow-up PR.