### PR TITLE
api: compute unit limit, price and jito tip

### DIFF
--- a/api/src/routers/tx.ts
+++ b/api/src/routers/tx.ts
@@ -11,12 +11,15 @@ router.use((req, res, next) => {
       return res.status(400).send({ error: "Invalid signer" });
     }
 
-    const microLamports = req.body.microLamports;
+    const computeUnitLimit = req.body.computeUnitLimit;
+    const computeUnitPriceMicroLamports =
+      req.body.computeUnitPriceMicroLamports || req.body.microLamports;
     const jitoTipLamports = req.body.jitoTipLamports;
 
     req.apiOptions = {
       signer,
-      microLamports,
+      computeUnitLimit,
+      computeUnitPriceMicroLamports,
       jitoTipLamports,
     };
   }


### PR DESCRIPTION
To add to doc:
- `computeUnitLimit`: set the compute unit limit. default: set dynamically by simulating the tx against a RPC node
- `computeUnitPriceMicroLamports`: fee in micro lamport (old `microLamports` renamed into `computeUnitPriceMicroLamports`)
- `jitoTipLamports`: add Jito tip. Note that (like in Jupiter) if this is set then `computeUnitPriceMicroLamports` is ignored.