### PR TITLE
sdk: downgrade @solana/spl-token version to 0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@scure/base": "^1.1.7",
     "@solana-developers/preset-react": "^3.0.1",
     "@solana/spl-stake-pool": "^1.1.5",
-    "@solana/spl-token": "^0.4.7",
+    "@solana/spl-token": "^0.3.9",
     "@solana/spl-token-metadata": "^0.1.4",
     "@solana/wallet-adapter-base": "^0.9.23",
     "@solana/wallet-adapter-react": "^0.15.35",
@@ -141,7 +141,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@solana/web3.js@>=1.73.0 <1.73.5": ">=1.73.5"
+      "@solana/web3.js@>=1.73.0 <1.73.5": ">=1.73.5",
+      "bs58@>=4.0.1": "^5.0.0"
     }
   },
   "packageManager": "pnpm@9.1.2+sha512.127dc83b9ea10c32be65d22a8efb4a65fb952e8fefbdfded39bdc3c97efc32d31b48b00420df2c1187ace28c921c902f0cb5a134a4d032b8b5295cbfa2c681e2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@solana/web3.js@>=1.73.0 <1.73.5': '>=1.73.5'
+  bs58@>=4.0.1: ^5.0.0
 
 importers:
 
@@ -78,8 +79,8 @@ importers:
         specifier: ^1.1.5
         version: 1.1.5(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@solana/spl-token':
-        specifier: ^0.4.7
-        version: 0.4.7(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
+        specifier: ^0.3.9
+        version: 0.3.11(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@solana/spl-token-metadata':
         specifier: ^0.1.4
         version: 0.1.4(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
@@ -2130,7 +2131,7 @@ packages:
     resolution: {integrity: sha512-KviKVP87OtWq813y8IumM3rIQMNkTjHBaQmCUbTWGebz3csFOv54JIoy1r+3J3NnA+mBxBdZeRedZ5g+07v75w==}
     peerDependencies:
       '@solana/web3.js': '>=1.73.5'
-      bs58: ^4.0.1
+      bs58: ^5.0.0
 
   '@phenomnomnominal/tsquery@5.0.1':
     resolution: {integrity: sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==}
@@ -3175,13 +3176,6 @@ packages:
   '@solana/spl-stake-pool@1.1.5':
     resolution: {integrity: sha512-fiZ7XRbtk4G4aDRdAFu+3rs0kNFv55dzfLd78HoADhrVNQT8B+vby7L02Zhp1f2DR8GPWqTQkBh5BdyAKrICBQ==}
 
-  '@solana/spl-token-group@0.0.3':
-    resolution: {integrity: sha512-oEHb/ATHbbzTwP1lNOhLM90lYcUgriMf7KA0L/W/t2OzBplS+5odNDRLccJ7lPstfrZLAAQXbqGGG7E27GXxQQ==}
-    engines: {node: '>=16'}
-    deprecated: CommonJS exports were broken in this release
-    peerDependencies:
-      '@solana/web3.js': ^1.91.6
-
   '@solana/spl-token-group@0.0.4':
     resolution: {integrity: sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==}
     engines: {node: '>=16'}
@@ -3209,12 +3203,6 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.91.6
-
-  '@solana/spl-token@0.4.7':
-    resolution: {integrity: sha512-HvfieHwdGfoz09tl1Ph4uNR48pzl2oXfgMC3NeQ0v3D/Dk6ejTGNPR6xgPbPQ1qJ0ZuyNZOrHudF+GZH3dBybA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@solana/web3.js': ^1.93.1
 
   '@solana/spl-type-length-value@0.1.0':
     resolution: {integrity: sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==}
@@ -3491,7 +3479,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': '>=1.73.5'
-      bs58: ^4.0.1
+      bs58: ^5.0.0
 
   '@solana/wallet-standard-wallet-adapter-react@1.1.2':
     resolution: {integrity: sha512-bN6W4QkzenyjUoUz3sC5PAed+z29icGtPh9VSmLl1ZrRO7NbFB49a8uwUUVXNxhL/ZbMsyVKhb9bNj47/p8uhQ==}
@@ -4994,9 +4982,6 @@ packages:
   bs-logger@0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
     engines: {node: '>= 6'}
-
-  bs58@4.0.1:
-    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
 
   bs58@5.0.0:
     resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
@@ -12018,7 +12003,7 @@ snapshots:
       '@solana/web3.js': 1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       base64-js: 1.5.1
       bn.js: 5.2.1
-      bs58: 4.0.1
+      bs58: 5.0.0
       buffer-layout: 1.2.2
       camelcase: 6.3.0
       cross-fetch: 3.1.8
@@ -12039,7 +12024,7 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@solana/web3.js': 1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
-      bs58: 4.0.1
+      bs58: 5.0.0
       buffer-layout: 1.2.2
       camelcase: 6.3.0
       cross-fetch: 3.1.8
@@ -14456,7 +14441,7 @@ snapshots:
       '@solana/web3.js': 1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       base64-js: 1.5.1
       bn.js: 5.2.1
-      bs58: 4.0.1
+      bs58: 5.0.0
       buffer-layout: 1.2.2
       camelcase: 5.3.1
       crypto-hash: 1.3.0
@@ -14492,7 +14477,7 @@ snapshots:
   '@project-serum/sol-wallet-adapter@0.2.6(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/web3.js': 1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      bs58: 4.0.1
+      bs58: 5.0.0
       eventemitter3: 4.0.7
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -15784,14 +15769,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/spl-token-group@0.0.3(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)':
-    dependencies:
-      '@solana/codecs': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/spl-type-length-value': 0.1.0
-      '@solana/web3.js': 1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
   '@solana/spl-token-group@0.0.4(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)':
     dependencies:
       '@solana/codecs': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
@@ -15839,20 +15816,6 @@ snapshots:
       '@solana/buffer-layout': 4.0.1
       '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@solana/spl-token-group': 0.0.4(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/web3.js': 1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      buffer: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - utf-8-validate
-
-  '@solana/spl-token@0.4.7(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@solana/spl-token-group': 0.0.3(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/web3.js': 1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       buffer: 6.0.3
@@ -15912,7 +15875,7 @@ snapshots:
     dependencies:
       '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      bs58: 4.0.1
+      bs58: 5.0.0
 
   '@solana/wallet-adapter-coinbase@0.1.19(@solana/web3.js@1.94.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
@@ -16298,7 +16261,7 @@ snapshots:
       bigint-buffer: 1.1.5
       bn.js: 5.2.1
       borsh: 0.7.0
-      bs58: 4.0.1
+      bs58: 5.0.0
       buffer: 6.0.3
       fast-stable-stringify: 1.0.0
       jayson: 4.1.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -18338,7 +18301,7 @@ snapshots:
   borsh@0.7.0:
     dependencies:
       bn.js: 5.2.1
-      bs58: 4.0.1
+      bs58: 5.0.0
       text-encoding-utf-8: 1.0.2
 
   bowser@2.11.0: {}
@@ -18409,17 +18372,13 @@ snapshots:
     dependencies:
       fast-json-stable-stringify: 2.1.0
 
-  bs58@4.0.1:
-    dependencies:
-      base-x: 3.0.10
-
   bs58@5.0.0:
     dependencies:
       base-x: 4.0.0
 
   bs58check@2.1.2:
     dependencies:
-      bs58: 4.0.1
+      bs58: 5.0.0
       create-hash: 1.2.0
       safe-buffer: 5.2.1
 


### PR DESCRIPTION
With 0.4.x api fails to start due to
```
/home/yurushao/code/glam/node_modules/.pnpm/@nx+js@19.4.1_@babel+traverse@7.24.7_@swc-node+register@1.10.2_@swc+core@1.6.13_@swc+helpers@_g672tg2qfjmhiqt75tcrmgrqkm/node_modules/@nx/js/src/executors/node/node-with-require-overrides.js:18
        return originalLoader.apply(this, arguments);
                              ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /home/yurushao/code/glam/node_modules/.pnpm/@solana+spl-token@0.4.7_@solana+web3.js@1.94.0_bufferutil@4.0.8_utf-8-validate@5.0.10__buffer_cm7s3xtqoolcjjb5wyg2kmm3dm/node_modules/@solana/spl-token/lib/cjs/index.js from /home/yurushao/code/glam/dist/api/main.js not supported.
```

Downgrading to 0.3.x resolves it.