### PR TITLE
anchor: create acl field

### DIFF
--- a/anchor/programs/glam/src/instructions/manager.rs
+++ b/anchor/programs/glam/src/instructions/manager.rs
@@ -306,6 +306,14 @@ pub fn update_fund_handler<'c: 'info, 'info>(
     //   * if acl.permissions is empty, delete the fund acl
     // - If a fund acl with same pubkey doesn't exist, add it
     if fund_model.acls.len() > 0 {
+        // For legacy funds, add the acls field if it doesn't exist
+        if fund.params[0].len() == 2 {
+            fund.params[0].push(EngineField {
+                name: EngineFieldName::Acls,
+                value: EngineFieldValue::VecAcl { val: Vec::new() },
+            });
+        }
+
         let to_delete: Vec<Pubkey> = fund_model
             .acls
             .clone()


### PR DESCRIPTION
Funds created before we introduced fund acls don't have the EngineField `Acl`. 

Create it when we detect funds when updating acls.
