### PR TITLE
[anchor] update compiler config to reduce binary size

### DIFF
--- a/anchor/Cargo.toml
+++ b/anchor/Cargo.toml
@@ -4,10 +4,10 @@ resolver = "2"
 
 [profile.release]
 overflow-checks = true
+opt-level = "z"
 lto = "fat"
-codegen-units = 1
-[profile.release.build-override]
-opt-level = 3
+strip = "symbols"
+debug = false
 incremental = false
 codegen-units = 1
 
@@ -18,9 +18,15 @@ solana-program = "=1.18.22"
 
 spl-stake-pool = { version = "1.0.0", features = ["no-entrypoint"] }
 anchor-gen = "0.3.1"
-spl-token = { version = "=4.0.1", default-features = false, features = ["no-entrypoint"] }
-spl-token-2022 = { version = "3.0.2", default-features = false, features = ["no-entrypoint"] }
-spl-associated-token-account = { version = "3.0.2", features = ["no-entrypoint"] }
+spl-token = { version = "=4.0.1", default-features = false, features = [
+    "no-entrypoint",
+] }
+spl-token-2022 = { version = "3.0.2", default-features = false, features = [
+    "no-entrypoint",
+] }
+spl-associated-token-account = { version = "3.0.2", features = [
+    "no-entrypoint",
+] }
 spl-token-metadata-interface = "0.3.3"
 spl-transfer-hook-interface = "0.6.3"
 pyth-sdk-solana = "0.10.1"


### PR DESCRIPTION
The key is the opt-level:

- "z" is for small binary size but might slow down execution
- opt-level=3 is for fast execution but increases binary size
- "s" is something in between

Let's prefer small binary size to save some SOL for mainnet deploy.