### PR TITLE
[api] add /metadata/:shareclass endpoint

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -9,6 +9,7 @@ import txRouter from "./routers/tx";
 import openfundsRouter from "./routers/openfunds";
 import fundRouter from "./routers/fund";
 import miscRouter from "./routers/misc";
+import shareClassRouter from "./routers/shareclass";
 
 import { GlamClient, JUPITER_API_DEFAULT } from "@glam/anchor";
 
@@ -63,6 +64,7 @@ app.use(imageRouter);
 // routers that need to use glam client must be registered after req.client is set
 app.use(fundRouter);
 app.use(openfundsRouter);
+app.use(shareClassRouter);
 
 // tx should be the last router
 app.use(txRouter);

--- a/api/src/routers/shareclass.ts
+++ b/api/src/routers/shareclass.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { validatePubkey } from "../validation";
+
+const router = Router();
+
+router.get("/metadata/:pubkey", async (req, res) => {
+  const pubkey = validatePubkey(req.params.pubkey);
+  if (!pubkey) {
+    return res.sendStatus(404);
+  }
+
+  res.set("content-type", "application/json");
+  res.send(
+    JSON.stringify({
+      name: "GLAM Managed SOL",
+      symbol: "gmSOL",
+      description: "GLAM Managed SOL is a managed fund that invests in SOL",
+      image: `https://api.glam.systems/image/${pubkey}.png`,
+    })
+  );
+});
+
+export default router;


### PR DESCRIPTION
The metadata endpoint should include `image` so that explorers can display token image.

<img width="785" alt="image" src="https://github.com/user-attachments/assets/767eedf7-f969-48a0-a1a9-e5da7bd5034c">