### PR TITLE
anchor: aum from external accounts

### DIFF
--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -24,10 +24,10 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
+# test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_drift"
-#test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_marinade"
+test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_marinade"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_jupiter"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_openfunds"

--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -25,9 +25,9 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 # test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
-#test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
+test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_drift"
-test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_marinade"
+# test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_marinade"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_jupiter"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_openfunds"

--- a/anchor/Anchor.toml
+++ b/anchor/Anchor.toml
@@ -24,10 +24,10 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-# test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
-test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
+test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_crud"
+#test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_investor"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_drift"
-# test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_marinade"
+#test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_marinade"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_staking"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_jupiter"
 #test = "../node_modules/.bin/nx run --skip-nx-cache anchor:jest --verbose --testPathPattern tests/ --testNamePattern glam_openfunds"

--- a/anchor/programs/glam/src/instructions/investor.rs
+++ b/anchor/programs/glam/src/instructions/investor.rs
@@ -900,13 +900,16 @@ fn split_remaining_accounts<'info>(
         }
     }
 
-    // #[cfg(not(feature = "mainnet"))]
-    // msg!(
-    //     "stake_accounts={:?}, marinade_tickets={:?}, accounts_for_pricing={:?}",
-    //     stake_accounts,
-    //     marinade_tickets,
-    //     accounts_for_pricing
-    // );
+    #[cfg(not(feature = "mainnet"))]
+    msg!(
+        "stake_accounts={:?}, marinade_tickets={:?}, accounts_for_pricing={:?}",
+        stake_accounts.iter().map(|a| a.key()).collect::<Vec<_>>(),
+        marinade_tickets.iter().map(|a| a.key()).collect::<Vec<_>>(),
+        accounts_for_pricing
+            .iter()
+            .map(|a| a.key())
+            .collect::<Vec<_>>()
+    );
 
     Ok((stake_accounts, marinade_tickets, accounts_for_pricing))
 }

--- a/anchor/programs/glam/src/instructions/investor.rs
+++ b/anchor/programs/glam/src/instructions/investor.rs
@@ -88,17 +88,16 @@ pub fn subscribe_handler<'c: 'info, 'info>(
     let fund = &ctx.accounts.fund;
     require!(fund.is_enabled(), InvestorError::FundNotActive);
 
-    let stake_accounts = fund.get_pubkeys_from_engine_field(EngineFieldName::StakeAccounts);
-    let marinade_tickets = fund.get_pubkeys_from_engine_field(EngineFieldName::MarinadeTickets);
+    let external_treasury_accounts =
+        fund.get_pubkeys_from_engine_field(EngineFieldName::ExternalTreasuryAccounts);
 
     #[cfg(not(feature = "mainnet"))]
     msg!(
-        "stake_accounts={:?} marinade_tickets={:?}",
-        stake_accounts,
-        marinade_tickets
+        "external_treasury_accounts={:?}",
+        external_treasury_accounts
     );
     require!(
-        stake_accounts.len() == 0 && marinade_tickets.len() == 0,
+        external_treasury_accounts.len() == 0,
         InvestorError::SubscribeRedeemPaused
     );
 
@@ -324,17 +323,16 @@ pub fn redeem_handler<'c: 'info, 'info>(
 ) -> Result<()> {
     let fund = &ctx.accounts.fund;
 
-    let stake_accounts = fund.get_pubkeys_from_engine_field(EngineFieldName::StakeAccounts);
-    let marinade_tickets = fund.get_pubkeys_from_engine_field(EngineFieldName::MarinadeTickets);
+    let external_treasury_accounts =
+        fund.get_pubkeys_from_engine_field(EngineFieldName::ExternalTreasuryAccounts);
 
     #[cfg(not(feature = "mainnet"))]
     msg!(
-        "stake_accounts={:?} marinade_tickets={:?}",
-        stake_accounts,
-        marinade_tickets
+        "external_treasury_accounts={:?}",
+        external_treasury_accounts
     );
     require!(
-        stake_accounts.len() == 0 && marinade_tickets.len() == 0,
+        external_treasury_accounts.len() == 0,
         InvestorError::SubscribeRedeemPaused
     );
 

--- a/anchor/programs/glam/src/instructions/marinade.rs
+++ b/anchor/programs/glam/src/instructions/marinade.rs
@@ -144,7 +144,10 @@ pub fn marinade_delayed_unstake<'c: 'info, 'info>(
 
     // Add new ticket account to the fund param
     let fund = &mut ctx.accounts.fund;
-    fund.add_to_engine_field(EngineFieldName::MarinadeTickets, ctx.accounts.ticket.key());
+    fund.add_to_engine_field(
+        EngineFieldName::ExternalTreasuryAccounts,
+        ctx.accounts.ticket.key(),
+    );
 
     Ok(())
 }
@@ -185,7 +188,7 @@ pub fn marinade_claim_tickets<'info>(
             let _ = claim(cpi_ctx);
 
             fund.delete_from_engine_field(
-                EngineFieldName::MarinadeTickets,
+                EngineFieldName::ExternalTreasuryAccounts,
                 ticket_account_info.key(),
             );
         });

--- a/anchor/programs/glam/src/instructions/stake.rs
+++ b/anchor/programs/glam/src/instructions/stake.rs
@@ -119,7 +119,7 @@ pub fn initialize_and_delegate_stake<'c: 'info, 'info>(
     // Add the stake account to the fund params
     let fund = &mut ctx.accounts.fund;
     fund.add_to_engine_field(
-        EngineFieldName::StakeAccounts,
+        EngineFieldName::ExternalTreasuryAccounts,
         ctx.accounts.treasury_stake_account.key(),
     );
 
@@ -217,7 +217,10 @@ pub fn withdraw_from_stake_accounts<'info>(
 
         let _ = withdraw(cpi_ctx, lamports, None);
 
-        fund.delete_from_engine_field(EngineFieldName::StakeAccounts, stake_account.key());
+        fund.delete_from_engine_field(
+            EngineFieldName::ExternalTreasuryAccounts,
+            stake_account.key(),
+        );
     });
 
     Ok(())
@@ -276,7 +279,7 @@ pub fn merge_stake_accounts<'c: 'info, 'info>(ctx: Context<MergeStakeAccounts>) 
     // Remove the from_stake account from the fund params
     let fund = &mut ctx.accounts.fund;
     fund.delete_from_engine_field(
-        EngineFieldName::StakeAccounts,
+        EngineFieldName::ExternalTreasuryAccounts,
         ctx.accounts.from_stake.key(),
     );
 
@@ -370,7 +373,10 @@ pub fn split_stake_account<'c: 'info, 'info>(
 
     // Add the new stake account to the fund params
     let fund = &mut ctx.accounts.fund;
-    fund.add_to_engine_field(EngineFieldName::StakeAccounts, ctx.accounts.new_stake.key());
+    fund.add_to_engine_field(
+        EngineFieldName::ExternalTreasuryAccounts,
+        ctx.accounts.new_stake.key(),
+    );
 
     Ok(())
 }
@@ -471,10 +477,13 @@ pub fn redelegate_stake<'c: 'info, 'info>(
     // Remove existing stake account from the fund params and add the new one
     let fund = &mut ctx.accounts.fund;
     fund.delete_from_engine_field(
-        EngineFieldName::StakeAccounts,
+        EngineFieldName::ExternalTreasuryAccounts,
         ctx.accounts.existing_stake.key(),
     );
-    fund.add_to_engine_field(EngineFieldName::StakeAccounts, ctx.accounts.new_stake.key());
+    fund.add_to_engine_field(
+        EngineFieldName::ExternalTreasuryAccounts,
+        ctx.accounts.new_stake.key(),
+    );
 
     Ok(())
 }

--- a/anchor/programs/glam/src/instructions/stake_pool.rs
+++ b/anchor/programs/glam/src/instructions/stake_pool.rs
@@ -122,7 +122,7 @@ pub struct StakePoolDepositStake<'info> {
     #[account(mut)]
     pub manager: Signer<'info>,
 
-    #[account(has_one = treasury)]
+    #[account(mut, has_one = treasury)]
     pub fund: Box<Account<'info, FundAccount>>,
 
     #[account(mut, seeds = [b"treasury".as_ref(), fund.key().as_ref()], bump)]
@@ -231,6 +231,12 @@ pub fn stake_pool_deposit_stake<'c: 'info, 'info>(
     for ix in vec_ix {
         let _ = invoke_signed(&ix, &account_infos, signer_seeds);
     }
+
+    let fund = &mut ctx.accounts.fund;
+    fund.delete_from_engine_field(
+        EngineFieldName::ExternalTreasuryAccounts,
+        ctx.accounts.treasury_stake_account.key(),
+    );
 
     Ok(())
 }
@@ -459,7 +465,7 @@ pub fn stake_pool_withdraw_stake<'c: 'info, 'info>(
     // Add stake account to the fund params
     let fund = &mut ctx.accounts.fund;
     fund.add_to_engine_field(
-        EngineFieldName::StakeAccounts,
+        EngineFieldName::ExternalTreasuryAccounts,
         ctx.accounts.treasury_stake_account.key(),
     );
 

--- a/anchor/programs/glam/src/state/accounts.rs
+++ b/anchor/programs/glam/src/state/accounts.rs
@@ -15,9 +15,8 @@ pub enum EngineFieldName {
     ShareClassBlocklist, // share class
     DelegateAcls,
     IntegrationAcls,
-    MarinadeTickets,
-    StakeAccounts,
-    LockUp, // share class
+    ExternalTreasuryAccounts, // external accounts with treasury assets
+    LockUp,                   // share class
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]

--- a/anchor/src/client/base.ts
+++ b/anchor/src/client/base.ts
@@ -206,7 +206,10 @@ export class BaseClient {
       }
     }
     if (units) {
-      units += 9500; // ComputeBudgetProgram.setComputeUnitLimit costs 150 CUs, add some extra as buffer
+      // ComputeBudgetProgram.setComputeUnitLimit costs 150 CUs
+      units += 150;
+      // More CUs for tests as logs are more verbose
+      !this.isMainnet() && (units += 10_000);
       instructions.unshift(ComputeBudgetProgram.setComputeUnitLimit({ units }));
     }
 

--- a/anchor/src/client/base.ts
+++ b/anchor/src/client/base.ts
@@ -12,6 +12,7 @@ import {
   Connection,
   LAMPORTS_PER_SOL,
   PublicKey,
+  StakeProgram,
   SystemProgram,
   Transaction,
   TransactionMessage,
@@ -34,6 +35,7 @@ import { ClusterOrCustom, GlamClientConfig } from "../clientConfig";
 import { FundModel, FundOpenfundsModel } from "../models";
 import { AssetMeta, ASSETS_MAINNET, ASSETS_TESTS } from "./assets";
 import base58 from "bs58";
+import { MARINADE_PROGRAM_ID } from "../constants";
 
 type FundAccount = IdlAccounts<Glam>["fundAccount"];
 type FundMetadataAccount = IdlAccounts<Glam>["fundMetadataAccount"];
@@ -204,7 +206,7 @@ export class BaseClient {
       }
     }
     if (units) {
-      units += 150; // ComputeBudgetProgram.setComputeUnitLimit costs 150 CUs
+      units += 9500; // ComputeBudgetProgram.setComputeUnitLimit costs 150 CUs, add some extra as buffer
       instructions.unshift(ComputeBudgetProgram.setComputeUnitLimit({ units }));
     }
 
@@ -374,6 +376,75 @@ export class BaseClient {
       }
       throw e;
     }
+  }
+  async getStakeAccounts(fundPDA: PublicKey): Promise<PublicKey[]> {
+    const STAKE_ACCOUNT_SIZE = 200;
+    const accounts = await this.provider.connection.getParsedProgramAccounts(
+      StakeProgram.programId,
+      {
+        filters: [
+          {
+            dataSize: STAKE_ACCOUNT_SIZE,
+          },
+          {
+            memcmp: {
+              offset: 12,
+              bytes: this.getTreasuryPDA(fundPDA).toBase58(),
+            },
+          },
+        ],
+      }
+    );
+    // order by lamports desc
+    return accounts
+      .sort((a, b) => b.account.lamports - a.account.lamports)
+      .map((a) => a.pubkey);
+  }
+
+  async getTickets(fundPDA: PublicKey): Promise<
+    {
+      address: PublicKey;
+      lamports: number;
+      createdEpoch: number;
+      isDue: boolean;
+    }[]
+  > {
+    // TicketAccount {
+    //   stateAddress: web3.PublicKey; // offset 8
+    //   beneficiary: web3.PublicKey;  // offset 40
+    //   lamportsAmount: BN;           // offset 72
+    //   createdEpoch: BN;
+    // }
+    const connection = this.provider.connection;
+    const accounts = await connection.getParsedProgramAccounts(
+      MARINADE_PROGRAM_ID,
+      {
+        filters: [
+          {
+            dataSize: 88,
+          },
+          {
+            memcmp: {
+              offset: 40,
+              bytes: this.getTreasuryPDA(fundPDA).toBase58(),
+            },
+          },
+        ],
+      }
+    );
+    const currentEpoch = await connection.getEpochInfo();
+    return accounts.map((a) => {
+      const lamports = Number((a.account.data as Buffer).readBigInt64LE(72));
+      const createdEpoch = Number(
+        (a.account.data as Buffer).readBigInt64LE(80)
+      );
+      return {
+        address: a.pubkey,
+        lamports,
+        createdEpoch,
+        isDue: currentEpoch.epoch > createdEpoch,
+      };
+    });
   }
 
   getOpenfundsPDA(fundPDA: PublicKey): PublicKey {

--- a/anchor/src/client/investor.ts
+++ b/anchor/src/client/investor.ts
@@ -95,7 +95,6 @@ export class InvestorClient {
     );
 
     // remaining accounts = treasury atas + pricing to compute AUM
-    // @ts-ignore
     const fundModel = await this.base.fetchFund(fund);
     const remainingAccounts = (fundModel.assets || []).flatMap((asset: any) => {
       const assetMeta = this.base.getAssetMeta(asset.toBase58());

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -3712,6 +3712,7 @@
     {
       "code": 6000,
 <<<<<<< HEAD
+<<<<<<< HEAD
       "name": "CloseNotEmptyError",
       "msg": "Error closing account: not empty"
     },
@@ -3757,14 +3758,19 @@
 =======
       "name": "FundNotActive",
       "msg": "Fund is not active"
+=======
+      "name": "TransfersDisabled",
+      "msg": "Policy violation: transfers disabled"
+>>>>>>> fe953d9 (activated stake calc)
     },
     {
       "code": 6001,
-      "name": "InvalidShareClass",
-      "msg": "Share class not allowed to subscribe"
+      "name": "AmountTooBig",
+      "msg": "Policy violation: amount too big"
     },
     {
       "code": 6002,
+<<<<<<< HEAD
       "name": "InvalidAssetSubscribe",
       "msg": "Asset not allowed to subscribe"
     },
@@ -3808,6 +3814,10 @@
       "name": "InvalidPolicyAccount",
       "msg": "Policy account is mandatory"
 >>>>>>> 601e7b9 (anchor: aum from external accounts)
+=======
+      "name": "LockOut",
+      "msg": "Policy violation: lock out period"
+>>>>>>> fe953d9 (activated stake calc)
     }
   ],
   "types": [

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -1,5 +1,5 @@
 {
-  "address": "Gco1pcjxCMYjKJjSNJ7mKV7qezeUTE7arXJgy7PAPNRc",
+  "address": "GLAMpLuXu78TA4ao3DPZvT1zQ7woxoQ8ahdYbhnqY9mP",
   "metadata": {
     "name": "glam",
     "version": "0.2.9",
@@ -3714,62 +3714,8 @@
   "errors": [
     {
       "code": 6000,
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "name": "CloseNotEmptyError",
-      "msg": "Error closing account: not empty"
-    },
-    {
-      "code": 6001,
-      "name": "NotAuthorizedError",
-      "msg": "Error: not authorized"
-    },
-    {
-      "code": 6002,
-      "name": "InvalidFundName",
-      "msg": "Invalid fund name: max 30 chars"
-    },
-    {
-      "code": 6003,
-      "name": "InvalidFundSymbol",
-      "msg": "Too many assets: max 50"
-    },
-    {
-      "code": 6004,
-      "name": "InvalidFundUri",
-      "msg": "Too many assets: max 20"
-    },
-    {
-      "code": 6005,
-      "name": "InvalidAssetsLen",
-      "msg": "Too many assets: max 100"
-    },
-    {
-      "code": 6006,
-      "name": "InvalidAssetsWeights",
-      "msg": "Number of weights should match number of assets"
-    },
-    {
-      "code": 6007,
-      "name": "InvalidAssetForSwap",
-      "msg": "Asset cannot be swapped"
-    },
-    {
-      "code": 6008,
-      "name": "InvalidSwap",
-      "msg": "Swap failed"
-=======
       "name": "FundNotActive",
       "msg": "Fund is not active"
-=======
-      "name": "TransfersDisabled",
-      "msg": "Policy violation: transfers disabled"
->>>>>>> fe953d9 (activated stake calc)
-=======
-      "name": "FundNotActive",
-      "msg": "Fund is not active"
->>>>>>> 333dc43 (test)
     },
     {
       "code": 6001,
@@ -3778,10 +3724,6 @@
     },
     {
       "code": 6002,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 333dc43 (test)
       "name": "InvalidAssetSubscribe",
       "msg": "Asset not allowed to subscribe"
     },
@@ -3824,14 +3766,6 @@
       "code": 6010,
       "name": "InvalidPolicyAccount",
       "msg": "Policy account is mandatory"
-<<<<<<< HEAD
->>>>>>> 601e7b9 (anchor: aum from external accounts)
-=======
-      "name": "LockOut",
-      "msg": "Policy violation: lock out period"
->>>>>>> fe953d9 (activated stake calc)
-=======
->>>>>>> 333dc43 (test)
     }
   ],
   "types": [

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -2550,7 +2550,8 @@
           "signer": true
         },
         {
-          "name": "fund"
+          "name": "fund",
+          "writable": true
         },
         {
           "name": "treasury",
@@ -3710,6 +3711,7 @@
   "errors": [
     {
       "code": 6000,
+<<<<<<< HEAD
       "name": "CloseNotEmptyError",
       "msg": "Error closing account: not empty"
     },
@@ -3752,6 +3754,60 @@
       "code": 6008,
       "name": "InvalidSwap",
       "msg": "Swap failed"
+=======
+      "name": "FundNotActive",
+      "msg": "Fund is not active"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidShareClass",
+      "msg": "Share class not allowed to subscribe"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidAssetSubscribe",
+      "msg": "Asset not allowed to subscribe"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidPricingOracle",
+      "msg": "Invalid oracle for asset price"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidRemainingAccounts",
+      "msg": "Invalid accounts: the transaction is malformed"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidTreasuryAccount",
+      "msg": "Invalid treasury ata"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidSignerAccount",
+      "msg": "Invalid signer ata"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidAssetPrice",
+      "msg": "Invalid asset price"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidStableCoinPriceForSubscribe",
+      "msg": "Subscription not allowed: invalid stable coin price"
+    },
+    {
+      "code": 6009,
+      "name": "SubscribeRedeemPaused",
+      "msg": "Fund is paused for subscription and redemption"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidPolicyAccount",
+      "msg": "Policy account is mandatory"
+>>>>>>> 601e7b9 (anchor: aum from external accounts)
     }
   ],
   "types": [
@@ -4013,10 +4069,7 @@
             "name": "IntegrationAcls"
           },
           {
-            "name": "MarinadeTickets"
-          },
-          {
-            "name": "StakeAccounts"
+            "name": "ExternalTreasuryAccounts"
           },
           {
             "name": "LockUp"

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -2990,7 +2990,10 @@
                 "path": "fund"
               }
             ]
-          }
+          },
+          "relations": [
+            "fund"
+          ]
         },
         {
           "name": "share_class",
@@ -3713,6 +3716,7 @@
       "code": 6000,
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       "name": "CloseNotEmptyError",
       "msg": "Error closing account: not empty"
     },
@@ -3762,15 +3766,22 @@
       "name": "TransfersDisabled",
       "msg": "Policy violation: transfers disabled"
 >>>>>>> fe953d9 (activated stake calc)
+=======
+      "name": "FundNotActive",
+      "msg": "Fund is not active"
+>>>>>>> 333dc43 (test)
     },
     {
       "code": 6001,
-      "name": "AmountTooBig",
-      "msg": "Policy violation: amount too big"
+      "name": "InvalidShareClass",
+      "msg": "Share class not allowed to subscribe"
     },
     {
       "code": 6002,
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 333dc43 (test)
       "name": "InvalidAssetSubscribe",
       "msg": "Asset not allowed to subscribe"
     },
@@ -3813,11 +3824,14 @@
       "code": 6010,
       "name": "InvalidPolicyAccount",
       "msg": "Policy account is mandatory"
+<<<<<<< HEAD
 >>>>>>> 601e7b9 (anchor: aum from external accounts)
 =======
       "name": "LockOut",
       "msg": "Policy violation: lock out period"
 >>>>>>> fe953d9 (activated stake calc)
+=======
+>>>>>>> 333dc43 (test)
     }
   ],
   "types": [

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -2996,7 +2996,10 @@ export type Glam = {
                 "path": "fund"
               }
             ]
-          }
+          },
+          "relations": [
+            "fund"
+          ]
         },
         {
           "name": "shareClass",
@@ -3719,6 +3722,7 @@ export type Glam = {
       "code": 6000,
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       "name": "closeNotEmptyError",
       "msg": "Error closing account: not empty"
     },
@@ -3768,15 +3772,22 @@ export type Glam = {
       "name": "transfersDisabled",
       "msg": "Policy violation: transfers disabled"
 >>>>>>> fe953d9 (activated stake calc)
+=======
+      "name": "fundNotActive",
+      "msg": "Fund is not active"
+>>>>>>> 333dc43 (test)
     },
     {
       "code": 6001,
-      "name": "amountTooBig",
-      "msg": "Policy violation: amount too big"
+      "name": "invalidShareClass",
+      "msg": "Share class not allowed to subscribe"
     },
     {
       "code": 6002,
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 333dc43 (test)
       "name": "invalidAssetSubscribe",
       "msg": "Asset not allowed to subscribe"
     },
@@ -3819,11 +3830,14 @@ export type Glam = {
       "code": 6010,
       "name": "invalidPolicyAccount",
       "msg": "Policy account is mandatory"
+<<<<<<< HEAD
 >>>>>>> 601e7b9 (anchor: aum from external accounts)
 =======
       "name": "lockOut",
       "msg": "Policy violation: lock out period"
 >>>>>>> fe953d9 (activated stake calc)
+=======
+>>>>>>> 333dc43 (test)
     }
   ],
   "types": [

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -2556,7 +2556,8 @@ export type Glam = {
           "signer": true
         },
         {
-          "name": "fund"
+          "name": "fund",
+          "writable": true
         },
         {
           "name": "treasury",
@@ -3716,6 +3717,7 @@ export type Glam = {
   "errors": [
     {
       "code": 6000,
+<<<<<<< HEAD
       "name": "closeNotEmptyError",
       "msg": "Error closing account: not empty"
     },
@@ -3758,6 +3760,60 @@ export type Glam = {
       "code": 6008,
       "name": "invalidSwap",
       "msg": "Swap failed"
+=======
+      "name": "fundNotActive",
+      "msg": "Fund is not active"
+    },
+    {
+      "code": 6001,
+      "name": "invalidShareClass",
+      "msg": "Share class not allowed to subscribe"
+    },
+    {
+      "code": 6002,
+      "name": "invalidAssetSubscribe",
+      "msg": "Asset not allowed to subscribe"
+    },
+    {
+      "code": 6003,
+      "name": "invalidPricingOracle",
+      "msg": "Invalid oracle for asset price"
+    },
+    {
+      "code": 6004,
+      "name": "invalidRemainingAccounts",
+      "msg": "Invalid accounts: the transaction is malformed"
+    },
+    {
+      "code": 6005,
+      "name": "invalidTreasuryAccount",
+      "msg": "Invalid treasury ata"
+    },
+    {
+      "code": 6006,
+      "name": "invalidSignerAccount",
+      "msg": "Invalid signer ata"
+    },
+    {
+      "code": 6007,
+      "name": "invalidAssetPrice",
+      "msg": "Invalid asset price"
+    },
+    {
+      "code": 6008,
+      "name": "invalidStableCoinPriceForSubscribe",
+      "msg": "Subscription not allowed: invalid stable coin price"
+    },
+    {
+      "code": 6009,
+      "name": "subscribeRedeemPaused",
+      "msg": "Fund is paused for subscription and redemption"
+    },
+    {
+      "code": 6010,
+      "name": "invalidPolicyAccount",
+      "msg": "Policy account is mandatory"
+>>>>>>> 601e7b9 (anchor: aum from external accounts)
     }
   ],
   "types": [
@@ -4019,10 +4075,7 @@ export type Glam = {
             "name": "integrationAcls"
           },
           {
-            "name": "marinadeTickets"
-          },
-          {
-            "name": "stakeAccounts"
+            "name": "externalTreasuryAccounts"
           },
           {
             "name": "lockUp"

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -3720,62 +3720,8 @@ export type Glam = {
   "errors": [
     {
       "code": 6000,
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "name": "closeNotEmptyError",
-      "msg": "Error closing account: not empty"
-    },
-    {
-      "code": 6001,
-      "name": "notAuthorizedError",
-      "msg": "Error: not authorized"
-    },
-    {
-      "code": 6002,
-      "name": "invalidFundName",
-      "msg": "Invalid fund name: max 30 chars"
-    },
-    {
-      "code": 6003,
-      "name": "invalidFundSymbol",
-      "msg": "Too many assets: max 50"
-    },
-    {
-      "code": 6004,
-      "name": "invalidFundUri",
-      "msg": "Too many assets: max 20"
-    },
-    {
-      "code": 6005,
-      "name": "invalidAssetsLen",
-      "msg": "Too many assets: max 100"
-    },
-    {
-      "code": 6006,
-      "name": "invalidAssetsWeights",
-      "msg": "Number of weights should match number of assets"
-    },
-    {
-      "code": 6007,
-      "name": "invalidAssetForSwap",
-      "msg": "Asset cannot be swapped"
-    },
-    {
-      "code": 6008,
-      "name": "invalidSwap",
-      "msg": "Swap failed"
-=======
       "name": "fundNotActive",
       "msg": "Fund is not active"
-=======
-      "name": "transfersDisabled",
-      "msg": "Policy violation: transfers disabled"
->>>>>>> fe953d9 (activated stake calc)
-=======
-      "name": "fundNotActive",
-      "msg": "Fund is not active"
->>>>>>> 333dc43 (test)
     },
     {
       "code": 6001,
@@ -3784,10 +3730,6 @@ export type Glam = {
     },
     {
       "code": 6002,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 333dc43 (test)
       "name": "invalidAssetSubscribe",
       "msg": "Asset not allowed to subscribe"
     },
@@ -3830,14 +3772,6 @@ export type Glam = {
       "code": 6010,
       "name": "invalidPolicyAccount",
       "msg": "Policy account is mandatory"
-<<<<<<< HEAD
->>>>>>> 601e7b9 (anchor: aum from external accounts)
-=======
-      "name": "lockOut",
-      "msg": "Policy violation: lock out period"
->>>>>>> fe953d9 (activated stake calc)
-=======
->>>>>>> 333dc43 (test)
     }
   ],
   "types": [

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -3718,6 +3718,7 @@ export type Glam = {
     {
       "code": 6000,
 <<<<<<< HEAD
+<<<<<<< HEAD
       "name": "closeNotEmptyError",
       "msg": "Error closing account: not empty"
     },
@@ -3763,14 +3764,19 @@ export type Glam = {
 =======
       "name": "fundNotActive",
       "msg": "Fund is not active"
+=======
+      "name": "transfersDisabled",
+      "msg": "Policy violation: transfers disabled"
+>>>>>>> fe953d9 (activated stake calc)
     },
     {
       "code": 6001,
-      "name": "invalidShareClass",
-      "msg": "Share class not allowed to subscribe"
+      "name": "amountTooBig",
+      "msg": "Policy violation: amount too big"
     },
     {
       "code": 6002,
+<<<<<<< HEAD
       "name": "invalidAssetSubscribe",
       "msg": "Asset not allowed to subscribe"
     },
@@ -3814,6 +3820,10 @@ export type Glam = {
       "name": "invalidPolicyAccount",
       "msg": "Policy account is mandatory"
 >>>>>>> 601e7b9 (anchor: aum from external accounts)
+=======
+      "name": "lockOut",
+      "msg": "Policy violation: lock out period"
+>>>>>>> fe953d9 (activated stake calc)
     }
   ],
   "types": [

--- a/anchor/tests/glam_investor.spec.ts
+++ b/anchor/tests/glam_investor.spec.ts
@@ -214,20 +214,6 @@ describe("glam_investor", () => {
     }
   }, /* timeout */ 15_000);
 
-  /*afterAll(async () => {
-    await program.methods
-      .close()
-      .accounts({
-        fund: fundPDA,
-        manager: manager.publicKey
-      })
-      .rpc();
-
-    // The account should no longer exist, returning null.
-    const closedAccount = await program.account.fund.fetchNullable(fundPDA);
-    expect(closedAccount).toBeNull();
-  });*/
-
   it("Fund created", async () => {
     try {
       const fund = await program.account.fundAccount.fetch(fundPDA);

--- a/anchor/tests/glam_marinade.spec.ts
+++ b/anchor/tests/glam_marinade.spec.ts
@@ -78,7 +78,7 @@ describe("glam_marinade", () => {
     // [
     //   { name: { assets: {} }, value: { vecPubkey: [Object] } },
     //   { name: { assetsWeights: {} }, value: { vecU32: [Object] } },
-    //   { name: { marinadeTickets: {} }, value: { vecPubkey: [Object] } }
+    //   { name: { externalTreasuryAccounts: {} }, value: { vecPubkey: [Object] } }
     // ]
     expect(fund.params[0][2].value.vecPubkey?.val.length).toBe(tickets.length);
   });


### PR DESCRIPTION
- [x] track all external accounts in one engine field 
- [x] in subscribe and redeem, split remaining accounts into 1) stake accounts 2) marinade tickets 3) pricing accounts
- [x] calculate lamports in stake accounts and marinade tickets
- [x] test cases