### PR TITLE
ci: temporary fix to anchor test

### DIFF
--- a/.github/workflows/post_commit_anchor_test.yml
+++ b/.github/workflows/post_commit_anchor_test.yml
@@ -57,4 +57,4 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: cd anchor ; anchor test -- --tools-version v1.43
+        run: cd anchor ; anchor test || anchor test -- --tools-version v1.43


### PR DESCRIPTION
`anchor test -- --tools-version v1.43` doesn't work in ci, see this failure https://github.com/glamsystems/glam/actions/runs/11171719747/job/31056975194

![image](https://github.com/user-attachments/assets/0693059e-aeb7-4060-a5a9-000d9626b5ee)

`anchor test` would fail but it prepares the file/folder needed, then the following `anchor test -- --tools-version v1.43` would pass
