### PR TITLE
pg: hide disabled routes in production

### DIFF
--- a/playground/next-env.d.ts
+++ b/playground/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/playground/src/components/Sidebar.tsx
+++ b/playground/src/components/Sidebar.tsx
@@ -3,9 +3,7 @@
 import React from "react";
 import {
   BoxModelIcon,
-  CardStackIcon,
   Component1Icon,
-  Crosshair2Icon,
   DashboardIcon,
   DiscIcon,
   DownloadIcon,
@@ -21,7 +19,6 @@ import {
   MixerVerticalIcon,
   MixIcon,
   PaddingIcon,
-  PersonIcon,
   PlusIcon,
   ShuffleIcon,
   StackIcon,
@@ -85,6 +82,9 @@ function SidebarItem({ route, text, shortcut, Icon }: SidebarItemProps) {
 }
 
 export default function Sidebar() {
+  const disabledRoutes =
+    process.env.NEXT_PUBLIC_DISABLED_ROUTES?.split(",") || [];
+
   const navList = [
     {
       group: "Investment",
@@ -183,9 +183,11 @@ export default function Sidebar() {
               </div>
             )}
             <ul className="list-none p-0 m-0">
-              {nav.items.map((item, itemIndex) => (
-                <SidebarItem key={itemIndex} {...item} />
-              ))}
+              {nav.items.map((item, itemIndex) =>
+                disabledRoutes.includes(item.route) ? null : (
+                  <SidebarItem key={itemIndex} {...item} />
+                )
+              )}
             </ul>
           </div>
         ))}


### PR DESCRIPTION
The env variable should looks like this:

```
  NEXT_PUBLIC_DISABLED_ROUTES=/openfunds,/access
```

We can easily add/edit/delete this env variable in GCP 
<img width="529" alt="image" src="https://github.com/user-attachments/assets/9312d5a4-1a07-4844-899f-26ba952baa73">
