### PR TITLE
Playground enhancements

### DIFF
--- a/playground/src/app/trade/page.tsx
+++ b/playground/src/app/trade/page.tsx
@@ -302,20 +302,18 @@ export default function Trade() {
           tokenList?.find((t: any) => t.address === ta.mint)?.symbol || ta.mint;
         return {
           name,
-          symbol: symbol === "SOL" ? "wSOL" : symbol,
+          symbol: symbol,
           address: ta.mint,
           decimals: ta.decimals,
-          balance: Number(ta.uiAmount),
+          balance:
+            /* combine SOL + wSOL balances */
+            symbol === "SOL"
+              ? Number(ta.uiAmount) +
+                Number(treasury?.balanceLamports || 0) / LAMPORTS_PER_SOL
+              : Number(ta.uiAmount),
         } as Asset;
       }) || [];
-    assets.push({
-      name: "Solana",
-      symbol: "SOL",
-      address: "",
-      decimals: 9,
-      balance: (treasury?.balanceLamports || 0) / LAMPORTS_PER_SOL,
-    });
-    setFromAsset(assets[0].symbol);
+    setFromAsset(assets.length > 0 ? assets[0].symbol : "SOL");
 
     const defaultTo =
       fund?.assets && fund?.assets.length > 1
@@ -820,7 +818,11 @@ export default function Trade() {
                       name="from"
                       label="From"
                       assets={fromAssetList}
-                      balance={NaN}
+                      balance={
+                        (fromAssetList || []).find(
+                          (asset) => asset.symbol === fromAsset
+                        )?.balance || 0
+                      }
                       selectedAsset={fromAsset}
                       onSelectAsset={setFromAsset}
                     />
@@ -847,9 +849,16 @@ export default function Trade() {
                             balance: 0,
                           } as Asset)
                       )}
-                      balance={NaN}
+                      balance={
+                        /* use fromAssetList because that's the list of tokens in treasury.
+                           all other tokens have 0 balance. */
+                        (fromAssetList || []).find(
+                          (asset) => asset.symbol === toAsset
+                        )?.balance || 0
+                      }
                       selectedAsset={toAsset}
                       onSelectAsset={setToAsset}
+                      disableAmountInput={true}
                     />
                   </div>
 

--- a/playground/src/app/trade/page.tsx
+++ b/playground/src/app/trade/page.tsx
@@ -564,6 +564,8 @@ export default function Trade() {
   const handleExactModeChange = (value: string) => {
     if (value) {
       swapForm.setValue("exactMode", value as "ExactIn" | "ExactOut");
+      swapForm.setValue("from", 0);
+      swapForm.setValue("to", 0);
     }
   };
 
@@ -716,6 +718,7 @@ export default function Trade() {
     }
   };
 
+  const exactMode = swapForm.watch("exactMode");
   return (
     <PageContentWrapper>
       <div className="w-4/6 self-center">
@@ -825,6 +828,7 @@ export default function Trade() {
                       }
                       selectedAsset={fromAsset}
                       onSelectAsset={setFromAsset}
+                      disableAmountInput={exactMode === "ExactOut"}
                     />
                     <Button
                       variant="outline"
@@ -858,7 +862,7 @@ export default function Trade() {
                       }
                       selectedAsset={toAsset}
                       onSelectAsset={setToAsset}
-                      disableAmountInput={true}
+                      disableAmountInput={exactMode === "ExactIn"}
                     />
                   </div>
 

--- a/playground/src/app/trade/page.tsx
+++ b/playground/src/app/trade/page.tsx
@@ -1332,6 +1332,7 @@ export default function Trade() {
                           balance={NaN}
                           selectedAsset="USDC"
                           disableAssetChange={true}
+                          disableAmountInput={true}
                         />
                       </div>
                     </>
@@ -1359,6 +1360,7 @@ export default function Trade() {
                           balance={NaN}
                           selectedAsset="USDC"
                           disableAssetChange={true}
+                          disableAmountInput={true}
                         />
                       </div>
                     </>
@@ -1405,6 +1407,7 @@ export default function Trade() {
                           disableAssetChange={true}
                           balance={NaN}
                           selectedAsset={toAsset}
+                          disableAmountInput={true}
                         />
                       </div>
                     </>
@@ -1796,6 +1799,7 @@ export default function Trade() {
                           selectedAsset={"USDC"}
                           balance={NaN}
                           disableAssetChange={true}
+                          disableAmountInput={true}
                         />
                       </div>
                     </>
@@ -1824,6 +1828,7 @@ export default function Trade() {
                           balance={NaN}
                           selectedAsset={"USDC"}
                           disableAssetChange={true}
+                          disableAmountInput={true}
                         />
                       </div>
                     </>

--- a/playground/src/app/wrap/page.tsx
+++ b/playground/src/app/wrap/page.tsx
@@ -45,10 +45,11 @@ export default function Wrap() {
 
   useEffect(() => {
     if (fundPDA) {
-      const solBalance = Number(treasury?.balanceLamports) / LAMPORTS_PER_SOL;
+      const solBalance =
+        Number(treasury?.balanceLamports || 0) / LAMPORTS_PER_SOL;
       const wSolBalance = Number(
         treasury?.tokenAccounts?.find((ta) => ta.mint === WSOL.toBase58())
-          ?.uiAmount
+          ?.uiAmount || 0
       );
       setSolBalance(solBalance);
       setWSolBalance(wSolBalance);

--- a/playground/src/components/AssetInput.tsx
+++ b/playground/src/components/AssetInput.tsx
@@ -134,6 +134,11 @@ export const AssetInput: React.FC<AssetInputProps> = ({
 
   hideBalance = hideBalance || Number.isNaN(balance);
 
+  let value = getValues()[name];
+  if (disableAmountInput && !value) {
+    value = "";
+  }
+
   return (
     <FormField
       control={control}
@@ -148,7 +153,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
                 type="number"
                 step="any"
                 ref={inputRef}
-                value={getValues()[name]}
+                value={value}
                 className="pr-20"
                 placeholder=""
                 onChange={(e) => handleInputChange(e.target.value)}

--- a/playground/src/components/AssetInput.tsx
+++ b/playground/src/components/AssetInput.tsx
@@ -134,11 +134,6 @@ export const AssetInput: React.FC<AssetInputProps> = ({
 
   hideBalance = hideBalance || Number.isNaN(balance);
 
-  let value = getValues()[name];
-  if (disableAmountInput && !value) {
-    value = "";
-  }
-
   return (
     <FormField
       control={control}
@@ -153,7 +148,11 @@ export const AssetInput: React.FC<AssetInputProps> = ({
                 type="number"
                 step="any"
                 ref={inputRef}
-                value={value}
+                value={
+                  disableAmountInput
+                    ? getValues()[name] || ""
+                    : getValues()[name]
+                }
                 className="pr-20"
                 placeholder=""
                 onChange={(e) => handleInputChange(e.target.value)}

--- a/playground/src/components/GlamSidebar.tsx
+++ b/playground/src/components/GlamSidebar.tsx
@@ -237,8 +237,10 @@ export default function RefactoredSidebar() {
         </SidebarHeader>
         <SidebarContent className="grow pt-2">
           {navList.map((nav, index) => {
-            const visibleItems = getVisibleItems(nav.items).filter((item) =>
-              prodEnabledRoutes?.includes(item.route)
+            const visibleItems = getVisibleItems(nav.items).filter(
+              (item) =>
+                process.env.NODE_ENV === "development" ||
+                prodEnabledRoutes?.includes(item.route)
             );
             if (visibleItems.length === 0) return null;
             return (


### PR DESCRIPTION
- [x] show all routes in dev
- [x] wrap: always show balance in unwrap (and wrap)
- [x] swap: merge balance of SOL & wSOL -> there's only SOL
- [x] swap: show balance from/to
- [x] swap: disable assetTo input on exact in (default)
- [x] asset input: when disabled, show empty if value is 0 (before it was showing 0, which is misleading)
- [x] swap: exact in/out enable/disables from/to (and reset the values to 0)
- [x] perp: disable notional (computed, but can't be modified)