### PR TITLE
anchor: enforce swap slippage limit

### DIFF
--- a/anchor/programs/glam/src/lib.rs
+++ b/anchor/programs/glam/src/lib.rs
@@ -773,6 +773,13 @@ pub mod glam {
         jupiter::swap_handler(ctx, amount, data)
     }
 
+    pub fn jupiter_set_max_swap_slippage(
+        ctx: Context<JupiterSetMaxSwapSlippage>,
+        slippage: u64,
+    ) -> Result<()> {
+        jupiter::set_max_swap_slippage_handler(ctx, slippage)
+    }
+
     //////////////////////////////////////////////////////////////////////
     // Jupiter vote
     //////////////////////////////////////////////////////////////////////

--- a/anchor/programs/glam/src/lib.rs
+++ b/anchor/programs/glam/src/lib.rs
@@ -773,6 +773,14 @@ pub mod glam {
         jupiter::swap_handler(ctx, amount, data)
     }
 
+    /// Sets the max swap slippage.
+    ///
+    /// # Parameters
+    /// - `ctx`: The context for the transaction.
+    /// - `slippage`: The maximum allowed slippage in basis points.
+    ///
+    /// # Permission required
+    /// - Owner only, delegates not allowed
     pub fn jupiter_set_max_swap_slippage(
         ctx: Context<JupiterSetMaxSwapSlippage>,
         slippage: u64,

--- a/anchor/programs/glam/src/state/accounts.rs
+++ b/anchor/programs/glam/src/state/accounts.rs
@@ -14,6 +14,7 @@ pub enum EngineFieldName {
     DriftMarketIndexesPerp,
     DriftMarketIndexesSpot,
     DriftOrderTypes,
+    MaxSwapSlippageBps,
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]

--- a/anchor/src/client/jupiter.ts
+++ b/anchor/src/client/jupiter.ts
@@ -99,6 +99,19 @@ export class JupiterSwapClient {
     return await this.base.sendAndConfirm(tx);
   }
 
+  public async setMaxSwapSlippage(
+    statePda: PublicKey,
+    slippageBps: number,
+    txOptions: TxOptions = {},
+  ): Promise<TransactionSignature> {
+    const tx = await this.setMaxSwapSlippageTx(
+      statePda,
+      slippageBps,
+      txOptions,
+    );
+    return await this.base.sendAndConfirm(tx);
+  }
+
   /*
    * API methods
    */
@@ -199,6 +212,25 @@ export class JupiterSwapClient {
     return this.base.intoVersionedTransaction({
       tx,
       lookupTables,
+      ...txOptions,
+    });
+  }
+
+  public async setMaxSwapSlippageTx(
+    statePda: PublicKey,
+    slippageBps: number,
+    txOptions: TxOptions = {},
+  ): Promise<VersionedTransaction> {
+    const signer = txOptions.signer || this.base.getSigner();
+    const tx = await this.base.program.methods
+      .jupiterSetMaxSwapSlippage(new BN(slippageBps))
+      .accounts({
+        state: statePda,
+        signer,
+      })
+      .transaction();
+    return this.base.intoVersionedTransaction({
+      tx,
       ...txOptions,
     });
   }

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -2164,6 +2164,16 @@
     },
     {
       "name": "jupiter_set_max_swap_slippage",
+      "docs": [
+        "Sets the max swap slippage.",
+        "",
+        "# Parameters",
+        "- `ctx`: The context for the transaction.",
+        "- `slippage`: The maximum allowed slippage in basis points.",
+        "",
+        "# Permission required",
+        "- Owner only, delegates not allowed"
+      ],
       "discriminator": [
         110,
         79,

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -2163,6 +2163,36 @@
       ]
     },
     {
+      "name": "jupiter_set_max_swap_slippage",
+      "discriminator": [
+        110,
+        79,
+        13,
+        71,
+        208,
+        111,
+        56,
+        66
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "slippage",
+          "type": "u64"
+        }
+      ]
+    },
+    {
       "name": "jupiter_swap",
       "docs": [
         "Swaps assets using Jupiter.",
@@ -6680,6 +6710,9 @@
           },
           {
             "name": "DriftOrderTypes"
+          },
+          {
+            "name": "MaxSwapSlippageBps"
           }
         ]
       }

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -2169,6 +2169,36 @@ export type Glam = {
       ]
     },
     {
+      "name": "jupiterSetMaxSwapSlippage",
+      "discriminator": [
+        110,
+        79,
+        13,
+        71,
+        208,
+        111,
+        56,
+        66
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "slippage",
+          "type": "u64"
+        }
+      ]
+    },
+    {
       "name": "jupiterSwap",
       "docs": [
         "Swaps assets using Jupiter.",
@@ -6686,6 +6716,9 @@ export type Glam = {
           },
           {
             "name": "driftOrderTypes"
+          },
+          {
+            "name": "maxSwapSlippageBps"
           }
         ]
       }

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -2170,6 +2170,16 @@ export type Glam = {
     },
     {
       "name": "jupiterSetMaxSwapSlippage",
+      "docs": [
+        "Sets the max swap slippage.",
+        "",
+        "# Parameters",
+        "- `ctx`: The context for the transaction.",
+        "- `slippage`: The maximum allowed slippage in basis points.",
+        "",
+        "# Permission required",
+        "- Owner only, delegates not allowed"
+      ],
       "discriminator": [
         110,
         79,

--- a/anchor/tests/glam_jupiter.spec.ts
+++ b/anchor/tests/glam_jupiter.spec.ts
@@ -418,6 +418,32 @@ describe("glam_jupiter", () => {
     expect(vaultMsol.amount.toString()).toEqual("42591005");
   });
 
+  it("Set max slippage and swap by providing quote params", async () => {
+    const amount = 50_000_000;
+    try {
+      const txSetMaxSlippage = await glamClient.jupiterSwap.setMaxSwapSlippage(
+        statePda,
+        100,
+      );
+      console.log("Set max slippage txSig", txSetMaxSlippage);
+
+      const txIdSwap = await glamClient.jupiterSwap.swap(statePda, {
+        inputMint: WSOL.toBase58(),
+        outputMint: MSOL.toBase58(),
+        amount,
+        slippageBps: 150,
+        swapMode: "ExactIn",
+        onlyDirectRoutes: true,
+        asLegacyTransaction: false,
+        maxAccounts: 18,
+      });
+      expect(txIdSwap).toBeUndefined();
+    } catch (e) {
+      // should fail due to slippage exceeding max allowed
+      expect(e.message).toEqual("Swap failed.");
+    }
+  }, 15_000);
+
   it("Swap by providing quote params", async () => {
     const amount = 50_000_000;
     try {
@@ -425,8 +451,7 @@ describe("glam_jupiter", () => {
         inputMint: WSOL.toBase58(),
         outputMint: MSOL.toBase58(),
         amount,
-        autoSlippage: true,
-        autoSlippageCollisionUsdValue: 1000,
+        slippageBps: 10,
         swapMode: "ExactIn",
         onlyDirectRoutes: true,
         asLegacyTransaction: false,


### PR DESCRIPTION
- Add a glam ix to set max slippage bps allowed
- Enforce max slippage in program before executing swaps

