### PR TITLE
anchor: check vote side change

### DIFF
--- a/anchor/programs/glam/src/error.rs
+++ b/anchor/programs/glam/src/error.rs
@@ -71,6 +71,9 @@ pub enum GlamError {
     #[msg("Invalid token account")]
     InvalidTokenAccount,
 
+    #[msg("Invalid vote side")]
+    InvalidVoteSide,
+
     // Subscription & redemption errors (45000-)
     #[msg("Invalid asset price")]
     InvalidAssetPrice = 45000,

--- a/anchor/programs/glam/src/lib.rs
+++ b/anchor/programs/glam/src/lib.rs
@@ -919,15 +919,20 @@ pub mod glam {
     ///
     /// # Parameters
     /// - `ctx`: The context for the transaction.
-    /// - `side`: The side to vote for.
+    /// - `new_side`: The side to vote for.
+    /// - `current_side`: The current side of the vote.
     ///
     /// # Permission required
     /// - Permission::VoteOnProposal
     ///
     /// # Integration required
     /// - Integration::JupiterVote
-    pub fn cast_vote<'info>(ctx: Context<CastVote>, side: u8) -> Result<()> {
-        jupiter::cast_vote_handler(ctx, side)
+    pub fn cast_vote<'info>(
+        ctx: Context<CastVote>,
+        new_side: u8,
+        current_side: Option<u8>,
+    ) -> Result<()> {
+        jupiter::cast_vote_handler(ctx, new_side, current_side)
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/anchor/src/client/jupiter.ts
+++ b/anchor/src/client/jupiter.ts
@@ -539,7 +539,7 @@ export class JupiterVoteClient {
 
     const escrow = this.getEscrowPda(vault);
     const tx = await this.base.program.methods
-      .castVote(side)
+      .castVote(side, null)
       .accounts({
         state: statePda,
         escrow,

--- a/anchor/target/idl/glam.json
+++ b/anchor/target/idl/glam.json
@@ -248,7 +248,8 @@
         "",
         "# Parameters",
         "- `ctx`: The context for the transaction.",
-        "- `side`: The side to vote for.",
+        "- `new_side`: The side to vote for.",
+        "- `current_side`: The current side of the vote.",
         "",
         "# Permission required",
         "- Permission::VoteOnProposal",
@@ -326,8 +327,14 @@
       ],
       "args": [
         {
-          "name": "side",
+          "name": "new_side",
           "type": "u8"
+        },
+        {
+          "name": "current_side",
+          "type": {
+            "option": "u8"
+          }
         }
       ]
     },
@@ -6401,6 +6408,11 @@
       "code": 50003,
       "name": "InvalidTokenAccount",
       "msg": "Invalid token account"
+    },
+    {
+      "code": 50004,
+      "name": "InvalidVoteSide",
+      "msg": "Invalid vote side"
     },
     {
       "code": 51000,

--- a/anchor/target/types/glam.ts
+++ b/anchor/target/types/glam.ts
@@ -254,7 +254,8 @@ export type Glam = {
         "",
         "# Parameters",
         "- `ctx`: The context for the transaction.",
-        "- `side`: The side to vote for.",
+        "- `new_side`: The side to vote for.",
+        "- `current_side`: The current side of the vote.",
         "",
         "# Permission required",
         "- Permission::VoteOnProposal",
@@ -332,8 +333,14 @@ export type Glam = {
       ],
       "args": [
         {
-          "name": "side",
+          "name": "newSide",
           "type": "u8"
+        },
+        {
+          "name": "currentSide",
+          "type": {
+            "option": "u8"
+          }
         }
       ]
     },
@@ -6407,6 +6414,11 @@ export type Glam = {
       "code": 50003,
       "name": "invalidTokenAccount",
       "msg": "Invalid token account"
+    },
+    {
+      "code": 50004,
+      "name": "invalidVoteSide",
+      "msg": "Invalid vote side"
     },
     {
       "code": 51000,


### PR DESCRIPTION
An optional arg `current_side` is added to castVote ix.

- For user-initiated votes this arg should be ignored.
- For fatcat-initiated votes, it is used to prevent fatcat from overriding user votes.